### PR TITLE
refactor: streamline traffic interface handling and improve concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to NetWatch will be documented in this file.
 
+## [Unreleased]
+- Move interface stat collection to a background thread so that netwatch is more responsive on Windows.
+
 ## [0.10.0] - 2026-04-11
 
 ### Added

--- a/src/app.rs
+++ b/src/app.rs
@@ -425,11 +425,12 @@ impl App {
         let dns = self.network_intel.dns_analytics();
         let alert_history: Vec<_> = self.network_intel.alert_history().iter().cloned().collect();
 
+        let interfaces = self.traffic.interfaces();
         self.incident_recorder.record(
             &packets,
             &connections,
             &health,
-            &self.traffic.interfaces,
+            &interfaces,
             self.process_bandwidth.ranked(),
             &dns,
             &alert_history,
@@ -488,8 +489,8 @@ impl App {
             self.connection_collector.update();
             let conns = self.connection_collector.connections.lock().unwrap();
             self.connection_timeline.update(&conns);
-            self.process_bandwidth
-                .update(&conns, &self.traffic.interfaces);
+            let interfaces = self.traffic.interfaces();
+            self.process_bandwidth.update(&conns, &interfaces);
         }
 
         // Drain eBPF connection events and update RTT monitor
@@ -519,7 +520,8 @@ impl App {
         self.sample_rtt_from_streams();
 
         // Feed interface rates to bandwidth alerts
-        for iface in &self.traffic.interfaces {
+        let interfaces = self.traffic.interfaces();
+        for iface in &interfaces {
             self.network_intel.on_interface_rate(InterfaceRateEvent {
                 iface: iface.name.clone(),
                 rx_bps: iface.rx_rate as u64,
@@ -554,13 +556,10 @@ impl App {
                 .unwrap()
                 .clone();
             let health = self.health_prober.status.lock().unwrap().clone();
-            let (rx_bps, tx_bps) = self
-                .traffic
-                .interfaces
-                .iter()
-                .fold((0.0f64, 0.0f64), |(rx, tx), i| {
-                    (rx + i.rx_rate, tx + i.tx_rate)
-                });
+            let interfaces = self.traffic.interfaces();
+            let (rx_bps, tx_bps) = interfaces.iter().fold((0.0f64, 0.0f64), |(rx, tx), i| {
+                (rx + i.rx_rate, tx + i.tx_rate)
+            });
             let rx_str = crate::ui::widgets::format_bytes_rate(rx_bps);
             let tx_str = crate::ui::widgets::format_bytes_rate(tx_bps);
             let snapshot = crate::collectors::insights::NetworkSnapshot::build(
@@ -932,7 +931,7 @@ fn scroll_tab(app: &mut App, delta: isize) {
                 clamp_scroll(app.scroll.insights_scroll, delta, usize::MAX);
         }
         Tab::Dashboard | Tab::Interfaces => {
-            let max = app.traffic.interfaces.len().saturating_sub(1);
+            let max = app.traffic.interface_count().saturating_sub(1);
             app.selected_interface = match (app.selected_interface, delta < 0) {
                 (Some(0) | None, true) => None,
                 (None, false) => Some(0_usize.min(max)),
@@ -1247,13 +1246,10 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
                 let packets = app.packet_collector.get_packets();
                 let conns = app.connection_collector.connections.lock().unwrap().clone();
                 let health = app.health_prober.status.lock().unwrap().clone();
-                let (rx_bps, tx_bps) = app
-                    .traffic
-                    .interfaces
-                    .iter()
-                    .fold((0.0f64, 0.0f64), |(rx, tx), i| {
-                        (rx + i.rx_rate, tx + i.tx_rate)
-                    });
+                let interfaces = app.traffic.interfaces();
+                let (rx_bps, tx_bps) = interfaces.iter().fold((0.0f64, 0.0f64), |(rx, tx), i| {
+                    (rx + i.rx_rate, tx + i.tx_rate)
+                });
                 let rx_str = crate::ui::widgets::format_bytes_rate(rx_bps);
                 let tx_str = crate::ui::widgets::format_bytes_rate(tx_bps);
                 let snapshot = crate::collectors::insights::NetworkSnapshot::build(

--- a/src/collectors/traffic.rs
+++ b/src/collectors/traffic.rs
@@ -1,5 +1,8 @@
 use crate::platform::{self, InterfaceStats};
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::Instant;
 
 const SPARKLINE_HISTORY: usize = 60;
@@ -21,10 +24,15 @@ pub struct InterfaceTraffic {
     pub tx_history: VecDeque<u64>,
 }
 
-pub struct TrafficCollector {
+struct TrafficState {
     prev_stats: HashMap<String, InterfaceStats>,
     prev_time: Instant,
-    pub interfaces: Vec<InterfaceTraffic>,
+    interfaces: Vec<InterfaceTraffic>,
+}
+
+pub struct TrafficCollector {
+    state: Arc<Mutex<TrafficState>>,
+    busy: Arc<AtomicBool>,
 }
 
 impl Default for TrafficCollector {
@@ -37,74 +45,115 @@ impl TrafficCollector {
     pub fn new() -> Self {
         let stats = platform::collect_interface_stats().unwrap_or_default();
         Self {
-            prev_stats: stats,
-            prev_time: Instant::now(),
-            interfaces: Vec::new(),
+            state: Arc::new(Mutex::new(TrafficState {
+                prev_stats: stats,
+                prev_time: Instant::now(),
+                interfaces: Vec::new(),
+            })),
+            busy: Arc::new(AtomicBool::new(false)),
         }
     }
 
-    pub fn update(&mut self) {
-        let now = Instant::now();
-        let elapsed = now.duration_since(self.prev_time).as_secs_f64();
-        if elapsed < 0.01 {
+    pub fn interfaces(&self) -> Vec<InterfaceTraffic> {
+        self.state.lock().unwrap().interfaces.clone()
+    }
+
+    pub fn interface_count(&self) -> usize {
+        self.state.lock().unwrap().interfaces.len()
+    }
+
+    pub fn interface_at(&self, index: usize) -> Option<InterfaceTraffic> {
+        self.state.lock().unwrap().interfaces.get(index).cloned()
+    }
+
+    pub fn update(&self) {
+        if self
+            .busy
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
             return;
         }
 
-        let current = match platform::collect_interface_stats() {
-            Ok(s) => s,
-            Err(_) => return,
-        };
+        let state = Arc::clone(&self.state);
+        let busy = Arc::clone(&self.busy);
 
-        let mut updated: Vec<InterfaceTraffic> = Vec::new();
-
-        for (name, cur) in &current {
-            let (rx_rate, tx_rate) = if let Some(prev) = self.prev_stats.get(name) {
-                let rx_diff = cur.rx_bytes.saturating_sub(prev.rx_bytes);
-                let tx_diff = cur.tx_bytes.saturating_sub(prev.tx_bytes);
-                (rx_diff as f64 / elapsed, tx_diff as f64 / elapsed)
-            } else {
-                (0.0, 0.0)
+        thread::spawn(move || {
+            let now = Instant::now();
+            let (prev_stats, prev_time, prev_interfaces) = {
+                let state = state.lock().unwrap();
+                let elapsed = now.duration_since(state.prev_time).as_secs_f64();
+                if elapsed < 0.01 {
+                    busy.store(false, Ordering::SeqCst);
+                    return;
+                }
+                (
+                    state.prev_stats.clone(),
+                    state.prev_time,
+                    state.interfaces.clone(),
+                )
             };
 
-            // Find existing history or start fresh
-            let (mut rx_hist, mut tx_hist) = self
-                .interfaces
-                .iter()
-                .find(|i| i.name == *name)
-                .map(|i| (i.rx_history.clone(), i.tx_history.clone()))
-                .unwrap_or_default();
+            let elapsed = now.duration_since(prev_time).as_secs_f64();
+            let current = match platform::collect_interface_stats() {
+                Ok(s) => s,
+                Err(_) => {
+                    busy.store(false, Ordering::SeqCst);
+                    return;
+                }
+            };
 
-            rx_hist.push_back(rx_rate as u64);
-            tx_hist.push_back(tx_rate as u64);
-            if rx_hist.len() > SPARKLINE_HISTORY {
-                rx_hist.pop_front();
+            let mut updated: Vec<InterfaceTraffic> = Vec::new();
+
+            for (name, cur) in &current {
+                let (rx_rate, tx_rate) = if let Some(prev) = prev_stats.get(name) {
+                    let rx_diff = cur.rx_bytes.saturating_sub(prev.rx_bytes);
+                    let tx_diff = cur.tx_bytes.saturating_sub(prev.tx_bytes);
+                    (rx_diff as f64 / elapsed, tx_diff as f64 / elapsed)
+                } else {
+                    (0.0, 0.0)
+                };
+
+                let (mut rx_hist, mut tx_hist) = prev_interfaces
+                    .iter()
+                    .find(|i| i.name == *name)
+                    .map(|i| (i.rx_history.clone(), i.tx_history.clone()))
+                    .unwrap_or_default();
+
+                rx_hist.push_back(rx_rate as u64);
+                tx_hist.push_back(tx_rate as u64);
+                if rx_hist.len() > SPARKLINE_HISTORY {
+                    rx_hist.pop_front();
+                }
+                if tx_hist.len() > SPARKLINE_HISTORY {
+                    tx_hist.pop_front();
+                }
+                rx_hist.make_contiguous();
+                tx_hist.make_contiguous();
+
+                updated.push(InterfaceTraffic {
+                    name: name.clone(),
+                    rx_rate,
+                    tx_rate,
+                    rx_bytes_total: cur.rx_bytes,
+                    tx_bytes_total: cur.tx_bytes,
+                    rx_packets: cur.rx_packets,
+                    tx_packets: cur.tx_packets,
+                    rx_errors: cur.rx_errors,
+                    tx_errors: cur.tx_errors,
+                    rx_drops: cur.rx_drops,
+                    tx_drops: cur.tx_drops,
+                    rx_history: rx_hist,
+                    tx_history: tx_hist,
+                });
             }
-            if tx_hist.len() > SPARKLINE_HISTORY {
-                tx_hist.pop_front();
-            }
-            rx_hist.make_contiguous();
-            tx_hist.make_contiguous();
 
-            updated.push(InterfaceTraffic {
-                name: name.clone(),
-                rx_rate,
-                tx_rate,
-                rx_bytes_total: cur.rx_bytes,
-                tx_bytes_total: cur.tx_bytes,
-                rx_packets: cur.rx_packets,
-                tx_packets: cur.tx_packets,
-                rx_errors: cur.rx_errors,
-                tx_errors: cur.tx_errors,
-                rx_drops: cur.rx_drops,
-                tx_drops: cur.tx_drops,
-                rx_history: rx_hist,
-                tx_history: tx_hist,
-            });
-        }
-
-        updated.sort_by(|a, b| a.name.cmp(&b.name));
-        self.interfaces = updated;
-        self.prev_stats = current;
-        self.prev_time = now;
+            updated.sort_by(|a, b| a.name.cmp(&b.name));
+            let mut state = state.lock().unwrap();
+            state.interfaces = updated;
+            state.prev_stats = current;
+            state.prev_time = now;
+            busy.store(false, Ordering::SeqCst);
+        });
     }
 }

--- a/src/collectors/traffic.rs
+++ b/src/collectors/traffic.rs
@@ -69,7 +69,7 @@ impl TrafficCollector {
     pub fn update(&self) {
         if self
             .busy
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_err()
         {
             return;
@@ -84,7 +84,7 @@ impl TrafficCollector {
                 let state = state.lock().unwrap();
                 let elapsed = now.duration_since(state.prev_time).as_secs_f64();
                 if elapsed < 0.01 {
-                    busy.store(false, Ordering::SeqCst);
+                    busy.store(false, Ordering::Release);
                     return;
                 }
                 (
@@ -98,7 +98,7 @@ impl TrafficCollector {
             let current = match platform::collect_interface_stats() {
                 Ok(s) => s,
                 Err(_) => {
-                    busy.store(false, Ordering::SeqCst);
+                    busy.store(false, Ordering::Release);
                     return;
                 }
             };
@@ -153,7 +153,7 @@ impl TrafficCollector {
             state.interfaces = updated;
             state.prev_stats = current;
             state.prev_time = now;
-            busy.store(false, Ordering::SeqCst);
+            busy.store(false, Ordering::Release);
         });
     }
 }

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -106,9 +106,8 @@ fn render_interface_table(f: &mut Frame, app: &App, area: Rect) {
     ])
     .height(1);
 
-    let rows: Vec<Row> = app
-        .traffic
-        .interfaces
+    let interfaces = app.traffic.interfaces();
+    let rows: Vec<Row> = interfaces
         .iter()
         .enumerate()
         .map(|(i, iface)| {
@@ -186,7 +185,7 @@ fn render_interface_table(f: &mut Frame, app: &App, area: Rect) {
 fn render_sparkline(f: &mut Frame, app: &App, area: Rect) {
     let selected = app
         .selected_interface
-        .and_then(|i| app.traffic.interfaces.get(i));
+        .and_then(|i| app.traffic.interface_at(i));
 
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -227,9 +226,8 @@ fn render_sparkline(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_bandwidth_graph(f: &mut Frame, app: &App, area: Rect) {
-    let active: Vec<_> = app
-        .traffic
-        .interfaces
+    let interfaces = app.traffic.interfaces();
+    let active: Vec<_> = interfaces
         .iter()
         .filter(|i| {
             app.interface_info
@@ -395,19 +393,10 @@ fn render_health(f: &mut Frame, app: &App, area: Rect) {
         .as_deref()
         .unwrap_or("—");
 
-    let total_errors: u64 = app
-        .traffic
-        .interfaces
-        .iter()
-        .map(|i| i.rx_errors + i.tx_errors)
-        .sum();
+    let interfaces = app.traffic.interfaces();
+    let total_errors: u64 = interfaces.iter().map(|i| i.rx_errors + i.tx_errors).sum();
 
-    let total_drops: u64 = app
-        .traffic
-        .interfaces
-        .iter()
-        .map(|i| i.rx_drops + i.tx_drops)
-        .sum();
+    let total_drops: u64 = interfaces.iter().map(|i| i.rx_drops + i.tx_drops).sum();
 
     let ebpf_span = match &app.ebpf_status {
         EbpfStatus::Active => {

--- a/src/ui/interfaces.rs
+++ b/src/ui/interfaces.rs
@@ -42,9 +42,8 @@ fn render_detail_table(f: &mut Frame, app: &App, area: Rect) {
     ])
     .height(1);
 
-    let rows: Vec<Row> = app
-        .traffic
-        .interfaces
+    let interfaces = app.traffic.interfaces();
+    let rows: Vec<Row> = interfaces
         .iter()
         .enumerate()
         .map(|(i, iface)| {
@@ -135,7 +134,7 @@ fn render_detail_table(f: &mut Frame, app: &App, area: Rect) {
 fn render_sparkline(f: &mut Frame, app: &App, area: Rect) {
     let selected = app
         .selected_interface
-        .and_then(|i| app.traffic.interfaces.get(i));
+        .and_then(|i| app.traffic.interface_at(i));
 
     let chunks = Layout::default()
         .direction(Direction::Horizontal)

--- a/src/ui/topology.rs
+++ b/src/ui/topology.rs
@@ -151,9 +151,8 @@ fn render_topology(f: &mut Frame, app: &App, area: Rect) {
         format!("{} +{}", iface_names[0], iface_names.len() - 1)
     };
 
-    let total_rx: f64 = app
-        .traffic
-        .interfaces
+    let interfaces = app.traffic.interfaces();
+    let total_rx: f64 = interfaces
         .iter()
         .filter(|i| {
             app.interface_info.iter().any(|info| {
@@ -162,9 +161,7 @@ fn render_topology(f: &mut Frame, app: &App, area: Rect) {
         })
         .map(|i| i.rx_rate)
         .sum();
-    let total_tx: f64 = app
-        .traffic
-        .interfaces
+    let total_tx: f64 = interfaces
         .iter()
         .filter(|i| {
             app.interface_info.iter().any(|info| {


### PR DESCRIPTION
On Windows, you can hit a keybinding and it will take 5 to 30 seconds to respond. It appears that the WindowsUI thread was blocking on the ntework/statistics collection.

This PR attempts to fix the responsiveness on Windows by doing the interface stat collection on a background thread. Also added some thread-safe accessor methods.

Whether you land this PR or not, thanks for creating such a cool app!
