### PR TITLE
fix: add -n flag to netstat -ib to prevent DNS reverse lookup hang

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -4,13 +4,17 @@ use std::collections::HashMap;
 use std::process::Command;
 
 pub fn collect_interface_stats() -> Result<HashMap<String, InterfaceStats>> {
-    let output = Command::new("netstat").args(["-ib"]).output()?;
+    let output = Command::new("netstat").args(["-ibn"]).output()?;
     let text = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_netstat_output(&text))
+}
+
+fn parse_netstat_output(text: &str) -> HashMap<String, InterfaceStats> {
     let mut stats: HashMap<String, InterfaceStats> = HashMap::new();
 
     for line in text.lines().skip(1) {
         let cols: Vec<&str> = line.split_whitespace().collect();
-        // netstat -ib columns: Name Mtu Network Address Ipkts Ierrs Ibytes Opkts Oerrs Obytes Coll
+        // netstat -ibn columns: Name Mtu Network Address Ipkts Ierrs Ibytes Opkts Oerrs Obytes Coll
         if cols.len() < 11 {
             continue;
         }
@@ -45,12 +49,16 @@ pub fn collect_interface_stats() -> Result<HashMap<String, InterfaceStats>> {
         );
     }
 
-    Ok(stats)
+    stats
 }
 
 pub fn collect_interface_info() -> Result<Vec<InterfaceInfo>> {
     let output = Command::new("ifconfig").output()?;
     let text = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_ifconfig_output(&text))
+}
+
+fn parse_ifconfig_output(text: &str) -> Vec<InterfaceInfo> {
     let mut interfaces = Vec::new();
     let mut current: Option<InterfaceInfo> = None;
 
@@ -95,5 +103,146 @@ pub fn collect_interface_info() -> Result<Vec<InterfaceInfo>> {
         interfaces.push(iface);
     }
 
-    Ok(interfaces)
+    interfaces
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NETSTAT_OUTPUT: &str = "\
+Name       Mtu   Network       Address             Ipkts Ierrs     Ibytes    Opkts Oerrs     Obytes  Coll
+lo0        16384 <Link#1>                         517138     0   83732104   517138     0   83732104     0
+lo0        16384 127           127.0.0.1          517138     0   83732104   517138     0   83732104     0
+lo0        16384 ::1/128       ::1                517138     0   83732104   517138     0   83732104     0
+en0        1500  <Link#2>      aa:bb:cc:dd:ee:ff  1sobig     0 1234567890  2345678     0  987654321     0
+en0        1500  10.0.0/24     10.0.0.50         9999999     0 1234567890  2345678     0  987654321     0
+gif0*      1280  <Link#3>                              0     0          0        0     0          0     0
+stf0*      1280  <Link#4>                              0     0          0        0     0          0     0
+utun0      1380  <Link#5>                           12345    0    2345678    23456     0    3456789     0
+utun0      1380  fe80::1%utun0 fe80::1             12345     0    2345678    23456     0    3456789     0";
+
+    #[test]
+    fn parse_netstat_basic_fields() {
+        let stats = parse_netstat_output(NETSTAT_OUTPUT);
+
+        // lo0's link-level row has no address so only 10 columns — parser
+        // picks up the inet row (11 columns) instead
+        let lo0 = stats.get("lo0").expect("lo0 should be present");
+        assert_eq!(lo0.rx_packets, 517_138);
+        assert_eq!(lo0.rx_errors, 0);
+        assert_eq!(lo0.rx_bytes, 83_732_104);
+        assert_eq!(lo0.tx_packets, 517_138);
+        assert_eq!(lo0.tx_bytes, 83_732_104);
+    }
+
+    #[test]
+    fn parse_netstat_deduplicates_interfaces() {
+        let stats = parse_netstat_output(NETSTAT_OUTPUT);
+
+        let en0 = stats.get("en0").expect("en0 should be present");
+        assert_eq!(en0.rx_packets, 0, "first row has unparseable Ipkts");
+        assert_eq!(en0.rx_bytes, 1_234_567_890);
+        assert_eq!(en0.tx_bytes, 987_654_321);
+        assert_ne!(en0.rx_packets, 9_999_999);
+    }
+
+    #[test]
+    fn parse_netstat_skips_short_rows() {
+        // empty address field collapses to 10 columns, below the 11-column threshold
+        let stats = parse_netstat_output(NETSTAT_OUTPUT);
+
+        assert!(!stats.contains_key("gif0*"));
+        assert!(!stats.contains_key("stf0*"));
+    }
+
+    #[test]
+    fn parse_netstat_unparseable_numbers_default_to_zero() {
+        let stats = parse_netstat_output(NETSTAT_OUTPUT);
+
+        let en0 = stats.get("en0").expect("en0 should be present");
+        assert_eq!(en0.rx_packets, 0, "unparseable rx_packets should be 0");
+        assert_eq!(en0.tx_packets, 2_345_678);
+        assert_eq!(en0.rx_bytes, 1_234_567_890);
+    }
+
+    #[test]
+    fn parse_netstat_empty_input() {
+        let stats = parse_netstat_output("");
+        assert!(stats.is_empty());
+    }
+
+    #[test]
+    fn parse_netstat_header_only() {
+        let stats = parse_netstat_output(
+            "Name  Mtu  Network  Address  Ipkts Ierrs Ibytes Opkts Oerrs Obytes Coll\n",
+        );
+        assert!(stats.is_empty());
+    }
+
+    const IFCONFIG_OUTPUT: &str = "\
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+\tinet 127.0.0.1 netmask 0xff000000
+\tinet6 ::1 prefixlen 128
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+\tether aa:bb:cc:dd:ee:ff
+\tinet6 fe80::aabb:ccff:fedd:eeff%en0 prefixlen 64 secured scopeid 0x4
+\tinet 10.0.0.50 netmask 0xffffff00 broadcast 10.0.0.255
+en1: flags=8822<BROADCAST,SMART,SIMPLEX,MULTICAST> mtu 1500
+\tether 11:22:33:44:55:66";
+
+    #[test]
+    fn parse_ifconfig_interface_count() {
+        let interfaces = parse_ifconfig_output(IFCONFIG_OUTPUT);
+        assert_eq!(interfaces.len(), 3);
+    }
+
+    #[test]
+    fn parse_ifconfig_up_flag() {
+        let interfaces = parse_ifconfig_output(IFCONFIG_OUTPUT);
+
+        let lo0 = interfaces.iter().find(|i| i.name == "lo0").unwrap();
+        assert!(lo0.is_up);
+
+        let en1 = interfaces.iter().find(|i| i.name == "en1").unwrap();
+        assert!(!en1.is_up, "en1 lacks UP flag");
+    }
+
+    #[test]
+    fn parse_ifconfig_addresses() {
+        let interfaces = parse_ifconfig_output(IFCONFIG_OUTPUT);
+
+        let en0 = interfaces.iter().find(|i| i.name == "en0").unwrap();
+        assert_eq!(en0.ipv4.as_deref(), Some("10.0.0.50"));
+        assert_eq!(en0.mac.as_deref(), Some("aa:bb:cc:dd:ee:ff"));
+        // %scope suffix stripped from fe80::aabb:ccff:fedd:eeff%en0
+        assert_eq!(en0.ipv6.as_deref(), Some("fe80::aabb:ccff:fedd:eeff"));
+    }
+
+    #[test]
+    fn parse_ifconfig_no_ip_addresses() {
+        let interfaces = parse_ifconfig_output(IFCONFIG_OUTPUT);
+
+        let en1 = interfaces.iter().find(|i| i.name == "en1").unwrap();
+        assert_eq!(en1.ipv4, None);
+        assert_eq!(en1.ipv6, None);
+        assert_eq!(en1.mac.as_deref(), Some("11:22:33:44:55:66"));
+    }
+
+    #[test]
+    fn parse_ifconfig_mtu() {
+        let interfaces = parse_ifconfig_output(IFCONFIG_OUTPUT);
+
+        let lo0 = interfaces.iter().find(|i| i.name == "lo0").unwrap();
+        assert_eq!(lo0.mtu, Some(16_384));
+
+        let en0 = interfaces.iter().find(|i| i.name == "en0").unwrap();
+        assert_eq!(en0.mtu, Some(1_500));
+    }
+
+    #[test]
+    fn parse_ifconfig_empty_input() {
+        let interfaces = parse_ifconfig_output("");
+        assert!(interfaces.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary 

`netwatch` hangs on launch on macOS when reverse DNS lookups are slow

## Steps to reproduce (macOS 26.4; v0.12.3)

1. run `cargo run` on a macOS system where reverse DNS (PTR) lookups are slow or timing out
  a. add a slow/unreachable DNS server as primary
     ```sh
     sudo networksetup -setdnsservers Wi-Fi 10.255.255.1 192.168.1.1
     ```
2. TUI never appears: blank screen, unresponsive to input
3. process requires `pkill netwatch` to terminate

more interfaces amplify the hang since each triggers a separate PTR lookup

## Fix
 - add `-n` flag to `netstat -ib` in the macOS platform collector to skip reverse DNS lookups
 - without `-n`, `netstat` performs PTR lookups for every address. on systems where lookups for link-local/multicast addresses time out, this blocks `TrafficCollector::new()` indefinitely, causing the app to hang on launch with a blank screen (requiring `pkill` to exit)
 - extract `parse_netstat_output()` and `parse_ifconfig_output()` for testability
 - add 12 unit tests covering field parsing, deduplication, short row handling, unparseable values, and edge cases

## Root cause

`collect_interface_stats()` in `src/platform/macos.rs` calls `netstat -ib` which attempts reverse DNS resolution for every address. systems with many interfaces (e.g. 30) amplify the per address timeout, causing the app to hang before the event loop starts

## Test plan
 - [x] `cargo test --lib platform::macos` (12 tests pass)
 - [x] verify `cargo run` starts immediately on macOS
 - [x] verify interface stats still display correctly on the dashboard tab