### PR TITLE
feat(sort): wire up per-tab sorting across all tabs [2/3]

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -75,7 +75,7 @@ pub enum StreamDirectionFilter {
     BtoA,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Tab {
     Dashboard,
     Connections,
@@ -86,6 +86,27 @@ pub enum Tab {
     Timeline,
     Processes,
     Insights,
+}
+
+use crate::sort::{SortColumn, TabSortState};
+
+pub fn sort_columns_for_tab(tab: Tab) -> &'static [SortColumn] {
+    match tab {
+        Tab::Dashboard => crate::ui::dashboard::COLUMNS,
+        Tab::Connections => crate::ui::connections::COLUMNS,
+        Tab::Interfaces => crate::ui::interfaces::COLUMNS,
+        Tab::Processes => crate::ui::processes::COLUMNS,
+        _ => &[],
+    }
+}
+
+pub fn default_sort_states() -> HashMap<Tab, TabSortState> {
+    let mut m = HashMap::new();
+    m.insert(Tab::Dashboard, crate::ui::dashboard::DEFAULT_SORT);
+    m.insert(Tab::Connections, crate::ui::connections::DEFAULT_SORT);
+    m.insert(Tab::Interfaces, crate::ui::interfaces::DEFAULT_SORT);
+    m.insert(Tab::Processes, crate::ui::processes::DEFAULT_SORT);
+    m
 }
 
 /// Per-tab scroll positions and selection state.
@@ -132,7 +153,7 @@ pub struct App {
     pub paused: bool,
     pub current_tab: Tab,
     pub scroll: UiScrollState,
-    pub sort_column: usize,
+    pub sort_states: HashMap<Tab, TabSortState>,
     pub packet_follow: bool,
     pub capture_interface: String,
     pub stream_view_open: bool,
@@ -176,6 +197,7 @@ pub struct App {
     pub theme: Theme,
     pub process_bandwidth: ProcessBandwidthCollector,
     pub insights_collector: Option<crate::collectors::insights::InsightsCollector>,
+    pub sort_picker: crate::ui::sort_picker::SortPickerState,
     pub show_settings: bool,
     pub settings_cursor: usize,
     pub settings_editing: bool,
@@ -239,7 +261,7 @@ impl App {
             paused: false,
             current_tab: user_config.tab(),
             scroll: UiScrollState::default(),
-            sort_column: 0,
+            sort_states: default_sort_states(),
             packet_follow: user_config.packet_follow,
             capture_interface,
             stream_view_open: false,
@@ -288,6 +310,28 @@ impl App {
             settings_status: None,
             settings_status_tick: 0,
             incident_capture_started: false,
+            sort_picker: Default::default(),
+        }
+    }
+
+    pub fn sort_column_index(&self, tab: Tab) -> Option<usize> {
+        self.sort_states.get(&tab).map(|s| s.column)
+    }
+
+    pub fn sort_indicator(&self, tab: Tab, col: usize) -> &str {
+        if self.sort_column_index(tab) == Some(col) {
+            let ascending = self
+                .sort_states
+                .get(&tab)
+                .map(|s| s.ascending)
+                .unwrap_or(true);
+            if ascending {
+                " ▲"
+            } else {
+                " ▼"
+            }
+        } else {
+            ""
         }
     }
 
@@ -749,6 +793,16 @@ pub async fn run<B: Backend>(
             if app.show_settings {
                 ui::settings::render(f, &app, area);
             }
+            if app.sort_picker.is_open() {
+                ui::sort_picker::render(
+                    f,
+                    &app.sort_picker,
+                    sort_columns_for_tab(app.current_tab),
+                    app.sort_states.get(&app.current_tab),
+                    &app.theme,
+                    area,
+                );
+            }
         })?;
 
         match events.next().await? {
@@ -964,6 +1018,35 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
     }
     if app.show_settings {
         return handle_settings_key(app, key);
+    }
+    if app.sort_picker.is_open() {
+        // auto-close if tab changed to a non-sortable tab (e.g. via mouse)
+        if sort_columns_for_tab(app.current_tab).is_empty() {
+            app.sort_picker.close();
+        } else {
+            let cols = sort_columns_for_tab(app.current_tab);
+            let action = app.sort_picker.handle_key(key, cols);
+            match action {
+                ui::sort_picker::PickerAction::Select(col_idx) => {
+                    let tab = app.current_tab;
+                    app.sort_states
+                        .entry(tab)
+                        .and_modify(|s| s.column = col_idx)
+                        .or_insert(TabSortState {
+                            column: col_idx,
+                            ascending: true,
+                        });
+                }
+                ui::sort_picker::PickerAction::ToggleDirection => {
+                    let tab = app.current_tab;
+                    if let Some(state) = app.sort_states.get_mut(&tab) {
+                        state.ascending = !state.ascending;
+                    }
+                }
+                ui::sort_picker::PickerAction::Close | ui::sort_picker::PickerAction::None => {}
+            }
+            return false;
+        }
     }
     // Text input modes
     if app.packet_filter_input && app.current_tab == Tab::Packets {
@@ -1385,7 +1468,12 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
         }
         KeyCode::Char('W') if app.current_tab == Tab::Connections => {
             let mut conns = app.connection_collector.connections.lock().unwrap().clone();
-            sort_connections(&mut conns, app.sort_column);
+            let sort_st = app.sort_states.get(&Tab::Connections);
+            crate::ui::connections::sort(
+                &mut conns,
+                sort_st.map(|s| s.column).unwrap_or(0),
+                sort_st.map(|s| s.ascending).unwrap_or(true),
+            );
             if let Some(conn) = conns.get(app.scroll.connection_scroll) {
                 let (remote_ip, _) = parse_addr_parts(&conn.remote_addr);
                 if let Some(ip) = remote_ip {
@@ -1395,7 +1483,12 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
         }
         KeyCode::Char('T') if app.current_tab == Tab::Connections && !app.traceroute_view_open => {
             let mut conns = app.connection_collector.connections.lock().unwrap().clone();
-            sort_connections(&mut conns, app.sort_column);
+            let sort_st = app.sort_states.get(&Tab::Connections);
+            crate::ui::connections::sort(
+                &mut conns,
+                sort_st.map(|s| s.column).unwrap_or(0),
+                sort_st.map(|s| s.ascending).unwrap_or(true),
+            );
             if let Some(conn) = conns.get(app.scroll.connection_scroll) {
                 let (remote_ip, _) = parse_addr_parts(&conn.remote_addr);
                 if let Some(ip) = remote_ip {
@@ -1442,16 +1535,17 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
             app.export_status_tick = 0;
         }
         KeyCode::Char('s') => {
-            if app.current_tab == Tab::Connections {
-                // Include the Down/Up sort column (6) only when any
-                // connection has rate data; otherwise wrap back to 0 after 5.
-                let conns = app.connection_collector.connections.lock().unwrap();
-                let has_rate = conns
-                    .iter()
-                    .any(|c| c.rx_rate.is_some() || c.tx_rate.is_some());
-                drop(conns);
-                let modulo = if has_rate { 7 } else { 6 };
-                app.sort_column = (app.sort_column + 1) % modulo;
+            let tab = app.current_tab;
+            let keys = sort_columns_for_tab(tab);
+            if !keys.is_empty() {
+                let current_col = app.sort_states.get(&tab).map(|s| s.column).unwrap_or(0);
+                app.sort_picker.open(current_col, keys.len());
+            }
+        }
+        KeyCode::Char('S') => {
+            let tab = app.current_tab;
+            if let Some(state) = app.sort_states.get_mut(&tab) {
+                state.ascending = !state.ascending;
             }
         }
         KeyCode::Char('t') if app.current_tab == Tab::Timeline => {
@@ -1486,7 +1580,12 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
         }
         KeyCode::Enter if app.current_tab == Tab::Connections => {
             let mut conns = app.connection_collector.connections.lock().unwrap().clone();
-            sort_connections(&mut conns, app.sort_column);
+            let sort_st = app.sort_states.get(&Tab::Connections);
+            crate::ui::connections::sort(
+                &mut conns,
+                sort_st.map(|s| s.column).unwrap_or(0),
+                sort_st.map(|s| s.ascending).unwrap_or(true),
+            );
             if let Some(conn) = conns.get(app.scroll.connection_scroll) {
                 let filter = build_connection_filter(conn);
                 app.packet_filter_text = filter.clone();
@@ -1558,32 +1657,6 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
     false
 }
 
-/// Returns connections sorted by `sort_column`:
-/// 0=process, 1=pid, 2=proto, 3=state, 4=local, 5=remote, 6=rate (rx+tx, descending).
-pub(crate) fn sort_connections(conns: &mut [Connection], sort_column: usize) {
-    match sort_column {
-        0 => conns.sort_by(|a, b| {
-            let an = a.process_name.as_deref().unwrap_or("");
-            let bn = b.process_name.as_deref().unwrap_or("");
-            an.to_lowercase()
-                .cmp(&bn.to_lowercase())
-                .then_with(|| an.cmp(bn))
-        }),
-        1 => conns.sort_by(|a, b| a.pid.cmp(&b.pid)),
-        2 => conns.sort_by(|a, b| a.protocol.cmp(&b.protocol)),
-        3 => conns.sort_by(|a, b| a.state.cmp(&b.state)),
-        4 => conns.sort_by(|a, b| a.local_addr.cmp(&b.local_addr)),
-        5 => conns.sort_by(|a, b| a.remote_addr.cmp(&b.remote_addr)),
-        6 => conns.sort_by(|a, b| {
-            let total = |c: &Connection| c.rx_rate.unwrap_or(0.0) + c.tx_rate.unwrap_or(0.0);
-            total(b)
-                .partial_cmp(&total(a))
-                .unwrap_or(std::cmp::Ordering::Equal)
-        }),
-        _ => {}
-    }
-}
-
 /// Returns remote IPs ranked by connection count, used by Topology tab actions.
 fn top_remote_ips(app: &App) -> Vec<(String, usize)> {
     let mut counts: HashMap<String, usize> = HashMap::new();
@@ -1597,57 +1670,4 @@ fn top_remote_ips(app: &App) -> Vec<(String, usize)> {
     let mut remote_ips: Vec<(String, usize)> = counts.into_iter().collect();
     remote_ips.sort_by(|a, b| b.1.cmp(&a.1));
     remote_ips
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn conn(process: Option<&str>) -> Connection {
-        Connection {
-            protocol: "TCP".into(),
-            local_addr: "127.0.0.1:0".into(),
-            remote_addr: "0.0.0.0:0".into(),
-            state: "ESTABLISHED".into(),
-            pid: None,
-            process_name: process.map(|s| s.to_string()),
-            kernel_rtt_us: None,
-            rx_rate: None,
-            tx_rate: None,
-        }
-    }
-
-    #[test]
-    fn process_name_sort_is_case_insensitive() {
-        // Mixed-case names should interleave in dictionary order regardless of
-        // case — on macOS this is the common case ("Finder", "facetime",
-        // "kernel_task") and byte-wise sort scatters them.
-        let mut conns = vec![
-            conn(Some("finder")),
-            conn(Some("Apple")),
-            conn(Some("zoom")),
-            conn(Some("Brave")),
-        ];
-        sort_connections(&mut conns, 0);
-        let order: Vec<_> = conns
-            .iter()
-            .map(|c| c.process_name.as_deref().unwrap())
-            .collect();
-        assert_eq!(order, vec!["Apple", "Brave", "finder", "zoom"]);
-    }
-
-    #[test]
-    fn process_name_sort_is_stable_on_case_only_difference() {
-        // When two names differ only in case, lowercase wins the tiebreaker
-        // (byte-wise cmp: 'A' < 'a'), but the important property is that the
-        // order is deterministic frame-to-frame.
-        let mut a = vec![conn(Some("finder")), conn(Some("Finder"))];
-        let mut b = vec![conn(Some("Finder")), conn(Some("finder"))];
-        sort_connections(&mut a, 0);
-        sort_connections(&mut b, 0);
-        let names = |v: &[Connection]| -> Vec<String> {
-            v.iter().map(|c| c.process_name.clone().unwrap()).collect()
-        };
-        assert_eq!(names(&a), names(&b));
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ebpf;
 pub mod event;
 pub mod platform;
 pub mod remote;
+pub mod sort;
 pub mod theme;
 pub mod ui;
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,0 +1,110 @@
+use std::cmp::Ordering;
+use std::net::IpAddr;
+
+// to add a new sortable column:
+// 1. add a SortColumn to the tab's COLUMNS array in its ui module
+// 2. add its comparator arm in the tab's sort function
+
+#[derive(Debug, Clone, Copy)]
+pub struct SortColumn {
+    pub name: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TabSortState {
+    pub column: usize,
+    pub ascending: bool,
+}
+
+// -- comparator helpers used by per-tab sort functions --
+
+/// Compare two "host:port" address strings by parsed IP octets, then port.
+/// Handles IPv4 ("1.2.3.4:80"), IPv6 ("[::1]:80"), and wildcard ("*:*").
+pub fn cmp_ip_addr(a: &str, b: &str) -> Ordering {
+    fn parse_host_port(s: &str) -> (Option<IpAddr>, u16) {
+        if s == "*:*" || s.is_empty() {
+            return (None, 0);
+        }
+        // IPv6 bracket notation: [::1]:port
+        if let Some(bracket_end) = s.rfind("]:") {
+            let ip_str = &s[1..bracket_end];
+            let port_str = &s[bracket_end + 2..];
+            let ip = ip_str.parse::<IpAddr>().ok();
+            let port = port_str.parse::<u16>().unwrap_or(0);
+            return (ip, port);
+        }
+        // IPv4 or plain: host:port (split on last colon)
+        if let Some(colon) = s.rfind(':') {
+            let host = &s[..colon];
+            let port_str = &s[colon + 1..];
+            let ip = if host == "*" {
+                None
+            } else {
+                host.parse::<IpAddr>().ok()
+            };
+            let port = if port_str == "*" {
+                0
+            } else {
+                port_str.parse::<u16>().unwrap_or(0)
+            };
+            return (ip, port);
+        }
+        (s.parse::<IpAddr>().ok(), 0)
+    }
+
+    let (ip_a, port_a) = parse_host_port(a);
+    let (ip_b, port_b) = parse_host_port(b);
+
+    // None (wildcard/unparseable) sorts before any real IP
+    let ip_ord = match (ip_a, ip_b) {
+        (None, None) => a.cmp(b),
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (Some(IpAddr::V4(a4)), Some(IpAddr::V4(b4))) => a4.octets().cmp(&b4.octets()),
+        (Some(IpAddr::V6(a6)), Some(IpAddr::V6(b6))) => a6.octets().cmp(&b6.octets()),
+        // IPv4 sorts before IPv6
+        (Some(IpAddr::V4(_)), Some(IpAddr::V6(_))) => Ordering::Less,
+        (Some(IpAddr::V6(_)), Some(IpAddr::V4(_))) => Ordering::Greater,
+    };
+    ip_ord.then_with(|| port_a.cmp(&port_b))
+}
+
+/// Compare two bare IP address strings (no port) by parsed octets.
+/// For interface addresses that aren't in host:port format.
+pub fn cmp_ip(a: &str, b: &str) -> Ordering {
+    let ip_a = a.parse::<IpAddr>().ok();
+    let ip_b = b.parse::<IpAddr>().ok();
+    match (ip_a, ip_b) {
+        (None, None) => a.cmp(b),
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (Some(IpAddr::V4(a4)), Some(IpAddr::V4(b4))) => a4.octets().cmp(&b4.octets()),
+        (Some(IpAddr::V6(a6)), Some(IpAddr::V6(b6))) => a6.octets().cmp(&b6.octets()),
+        (Some(IpAddr::V4(_)), Some(IpAddr::V6(_))) => Ordering::Less,
+        (Some(IpAddr::V6(_)), Some(IpAddr::V4(_))) => Ordering::Greater,
+    }
+}
+
+/// Case-insensitive string comparison with case as tiebreaker.
+/// Uses char-level lowering to avoid allocating two Strings per call.
+pub fn cmp_case_insensitive(a: &str, b: &str) -> Ordering {
+    let lower_ord = a
+        .chars()
+        .flat_map(char::to_lowercase)
+        .cmp(b.chars().flat_map(char::to_lowercase));
+    lower_ord.then_with(|| a.cmp(b))
+}
+
+/// Compare two f64 values with total ordering (NaN sorts after infinity).
+pub fn cmp_f64(a: f64, b: f64) -> Ordering {
+    a.total_cmp(&b)
+}
+
+/// Apply sort direction: if descending, reverse the ordering.
+pub fn apply_direction(ord: Ordering, ascending: bool) -> Ordering {
+    if ascending {
+        ord
+    } else {
+        ord.reverse()
+    }
+}

--- a/src/ui/connections.rs
+++ b/src/ui/connections.rs
@@ -1,9 +1,63 @@
 use crate::app::App;
 use crate::collectors::traceroute::TracerouteStatus;
+use crate::sort::{
+    apply_direction, cmp_case_insensitive, cmp_f64, cmp_ip_addr, SortColumn, TabSortState,
+};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table},
 };
+
+pub const COLUMNS: &[SortColumn] = &[
+    SortColumn { name: "Process" },
+    SortColumn { name: "PID" },
+    SortColumn { name: "Proto" },
+    SortColumn { name: "State" },
+    SortColumn {
+        name: "Local Address",
+    },
+    SortColumn {
+        name: "Remote Address",
+    },
+    SortColumn { name: "Down/Up" }, // RATE_COL — conditionally shown, see render
+];
+
+pub const DEFAULT_SORT: TabSortState = TabSortState {
+    column: 0,
+    ascending: true,
+};
+
+// index of the Down/Up column in COLUMNS (conditionally visible)
+const RATE_COL: usize = 6;
+
+pub fn sort(
+    conns: &mut [crate::collectors::connections::Connection],
+    column: usize,
+    ascending: bool,
+) {
+    let col_name = COLUMNS.get(column).map(|c| c.name).unwrap_or("");
+    conns.sort_by(|a, b| {
+        let ord = match col_name {
+            "Process" => cmp_case_insensitive(
+                a.process_name.as_deref().unwrap_or(""),
+                b.process_name.as_deref().unwrap_or(""),
+            ),
+            "PID" => a.pid.cmp(&b.pid),
+            "Proto" => cmp_case_insensitive(&a.protocol, &b.protocol),
+            "State" => cmp_case_insensitive(&a.state, &b.state),
+            "Local Address" => cmp_ip_addr(&a.local_addr, &b.local_addr),
+            "Remote Address" => cmp_ip_addr(&a.remote_addr, &b.remote_addr),
+            "Down/Up" => {
+                let total = |c: &crate::collectors::connections::Connection| {
+                    c.rx_rate.unwrap_or(0.0) + c.tx_rate.unwrap_or(0.0)
+                };
+                cmp_f64(total(a), total(b))
+            }
+            _ => std::cmp::Ordering::Equal,
+        };
+        apply_direction(ord, ascending)
+    });
+}
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let layout = crate::ui::widgets::frame_layout(area);
@@ -66,13 +120,7 @@ fn matches_filter(conn: &crate::collectors::connections::Connection, filter: &st
 }
 
 fn render_connection_table(f: &mut Frame, app: &App, area: Rect) {
-    let sort_indicator = |col: usize| -> &str {
-        if app.sort_column == col {
-            " ▼"
-        } else {
-            ""
-        }
-    };
+    let tab = crate::app::Tab::Connections;
 
     let mut conns = app.connection_collector.connections.lock().unwrap().clone();
     if let Some(ref f) = active_connection_filter(app) {
@@ -84,40 +132,33 @@ fn render_connection_table(f: &mut Frame, app: &App, area: Rect) {
         .any(|c| c.rx_rate.is_some() || c.tx_rate.is_some());
     let has_sparkline_data = !app.rtt_history.is_empty();
 
-    let mut header_cells = vec![
-        Cell::from(format!("Process{}", sort_indicator(0)))
-            .style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from(format!("PID{}", sort_indicator(1)))
-            .style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from(format!("Proto{}", sort_indicator(2)))
-            .style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from(format!("State{}", sort_indicator(3)))
-            .style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from(format!("Local Address{}", sort_indicator(4)))
-            .style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from(format!("Remote Address{}", sort_indicator(5)))
-            .style(Style::default().fg(app.theme.brand).bold()),
-    ];
-    if has_rate_data {
-        header_cells.push(
-            Cell::from(format!("Down/Up{}", sort_indicator(6)))
-                .style(Style::default().fg(app.theme.brand).bold()),
-        );
-    }
+    // header cells generated from COLUMNS — adding a name to COLUMNS
+    // automatically adds the header with sort indicator (▲/▼)
+    let header_style = Style::default().fg(app.theme.brand).bold();
+    let mut header_cells: Vec<Cell> = COLUMNS
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != RATE_COL || has_rate_data)
+        .map(|(i, col)| {
+            Cell::from(format!("{}{}", col.name, app.sort_indicator(tab, i))).style(header_style)
+        })
+        .collect();
+    // non-sortable display-only columns
     if has_rtt_data {
-        header_cells.push(Cell::from("RTT").style(Style::default().fg(app.theme.brand).bold()));
+        header_cells.push(Cell::from("RTT").style(header_style));
     }
     if has_sparkline_data {
-        header_cells
-            .push(Cell::from("RTT Trend").style(Style::default().fg(app.theme.brand).bold()));
+        header_cells.push(Cell::from("RTT Trend").style(header_style));
     }
     if app.show_geo {
-        header_cells
-            .push(Cell::from("Location").style(Style::default().fg(app.theme.brand).bold()));
+        header_cells.push(Cell::from("Location").style(header_style));
     }
     let header = Row::new(header_cells).height(1);
 
-    crate::app::sort_connections(&mut conns, app.sort_column);
+    let conn_sort = app.sort_states.get(&crate::app::Tab::Connections);
+    let sort_col = conn_sort.map(|s| s.column).unwrap_or(0);
+    let sort_asc = conn_sort.map(|s| s.ascending).unwrap_or(true);
+    sort(&mut conns, sort_col, sort_asc);
 
     let visible_rows = area.height.saturating_sub(3) as usize; // borders + header
     let scroll = app

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1,10 +1,26 @@
 use crate::app::App;
 use crate::ebpf::EbpfStatus;
+use crate::sort::{SortColumn, TabSortState};
 use crate::theme::Theme;
 use crate::ui::widgets;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Cell, Paragraph, Row, Sparkline, Table},
+};
+
+pub const COLUMNS: &[SortColumn] = &[
+    SortColumn { name: "Interface" },
+    SortColumn { name: "IP Address" },
+    SortColumn { name: "Rx Rate" },
+    SortColumn { name: "Tx Rate" },
+    SortColumn { name: "Rx Total" },
+    SortColumn { name: "Tx Total" },
+    SortColumn { name: "Status" },
+];
+
+pub const DEFAULT_SORT: TabSortState = TabSortState {
+    column: 0,
+    ascending: true,
 };
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
@@ -33,13 +49,27 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         ])
         .split(area);
 
+    // sort interfaces once, share between table and sparkline so
+    // selected_interface index refers to the same sorted order
+    let mut sorted_interfaces = app.traffic.interfaces();
+    let sort_state = app.sort_states.get(&crate::app::Tab::Dashboard);
+    if let Some(state) = sort_state {
+        crate::ui::interfaces::sort_interfaces(
+            &mut sorted_interfaces,
+            crate::app::Tab::Dashboard,
+            state.column,
+            state.ascending,
+            &app.interface_info,
+        );
+    }
+
     render_header(f, app, chunks[0]);
     if alert_count > 0 {
         render_alerts(f, app, chunks[1]);
     }
-    render_interface_table(f, app, chunks[2]);
+    render_interface_table(f, app, &sorted_interfaces, chunks[2]);
     if app.selected_interface.is_some() {
-        render_sparkline(f, app, chunks[3]);
+        render_sparkline(f, app, &sorted_interfaces, chunks[3]);
     } else {
         render_bandwidth_graph(f, app, chunks[3]);
     }
@@ -94,19 +124,15 @@ fn render_alerts(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(alert_widget, area);
 }
 
-fn render_interface_table(f: &mut Frame, app: &App, area: Rect) {
-    let header = Row::new(vec![
-        Cell::from("Interface").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("IP Address").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("RX Rate").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("TX Rate").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("RX Total").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("TX Total").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("Status").style(Style::default().fg(app.theme.brand).bold()),
-    ])
-    .height(1);
+fn render_interface_table(
+    f: &mut Frame,
+    app: &App,
+    interfaces: &[crate::collectors::traffic::InterfaceTraffic],
+    area: Rect,
+) {
+    let tab = crate::app::Tab::Dashboard;
+    let header = widgets::sort_header_row(app, tab, COLUMNS);
 
-    let interfaces = app.traffic.interfaces();
     let rows: Vec<Row> = interfaces
         .iter()
         .enumerate()
@@ -182,10 +208,16 @@ fn render_interface_table(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(table, area);
 }
 
-fn render_sparkline(f: &mut Frame, app: &App, area: Rect) {
+fn render_sparkline(
+    f: &mut Frame,
+    app: &App,
+    sorted_interfaces: &[crate::collectors::traffic::InterfaceTraffic],
+    area: Rect,
+) {
+    // look up from the sorted list so the sparkline matches the highlighted row
     let selected = app
         .selected_interface
-        .and_then(|i| app.traffic.interface_at(i));
+        .and_then(|i| sorted_interfaces.get(i));
 
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -556,6 +588,8 @@ fn render_latency_heatmap(f: &mut Frame, app: &App, area: Rect) {
 
 fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     let hints = vec![
+        Span::styled("s", Style::default().fg(app.theme.key_hint).bold()),
+        Span::raw(":Sort  "),
         Span::styled("p", Style::default().fg(app.theme.key_hint).bold()),
         Span::raw(":Pause  "),
         Span::styled("r", Style::default().fg(app.theme.key_hint).bold()),

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -111,12 +111,22 @@ fn build_help_lines() -> Vec<Line<'static>> {
     // DASHBOARD
     lines.push(section_header("DASHBOARD (Tab 1)"));
     lines.push(key_line("↑↓", "Select interface"));
+    lines.push(key_line("s", "Open sort picker"));
+    lines.push(Line::raw(""));
+
+    // SORT PICKER
+    lines.push(section_header("SORT PICKER (any table tab)"));
+    lines.push(key_line("↑↓ / j/k", "Move selection"));
+    lines.push(key_line("Enter", "Apply selected sort column"));
+    lines.push(key_line("S (shift)", "Toggle ascending/descending"));
+    lines.push(key_line("/", "Filter columns by name"));
+    lines.push(key_line("Esc / s / q", "Close picker"));
     lines.push(Line::raw(""));
 
     // CONNECTIONS
     lines.push(section_header("CONNECTIONS (Tab 2)"));
     lines.push(key_line("↑↓", "Scroll connection list"));
-    lines.push(key_line("s", "Cycle sort column"));
+    lines.push(key_line("s", "Open sort picker"));
     lines.push(key_line(
         "/",
         "Filter connections (process, state, remote address)",
@@ -140,6 +150,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
     // INTERFACES
     lines.push(section_header("INTERFACES (Tab 3)"));
     lines.push(key_line("↑↓", "Select interface"));
+    lines.push(key_line("s", "Open sort picker"));
     lines.push(Line::raw(""));
 
     // PACKETS
@@ -199,7 +210,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
     // PROCESSES
     lines.push(section_header("PROCESSES (Tab 8)"));
     lines.push(key_line("↑↓", "Scroll process list"));
-    lines.push(key_line("s", "Cycle sort column"));
+    lines.push(key_line("s", "Open sort picker"));
     lines.push(key_line("e", "Export connections to JSON + CSV"));
     lines.push(Line::raw(""));
 

--- a/src/ui/interfaces.rs
+++ b/src/ui/interfaces.rs
@@ -1,9 +1,90 @@
-use crate::app::App;
+use crate::app::{sort_columns_for_tab, App, Tab};
+use crate::sort::{
+    apply_direction, cmp_case_insensitive, cmp_f64, cmp_ip, SortColumn, TabSortState,
+};
 use crate::ui::widgets;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Cell, Paragraph, Row, Sparkline, Table},
 };
+
+pub const COLUMNS: &[SortColumn] = &[
+    SortColumn { name: "Name" },
+    SortColumn { name: "IPv4" },
+    SortColumn { name: "IPv6" },
+    SortColumn { name: "MAC" },
+    SortColumn { name: "MTU" },
+    SortColumn { name: "RX B/s" },
+    SortColumn { name: "TX B/s" },
+    SortColumn { name: "RX Pkts" },
+    SortColumn { name: "TX Pkts" },
+    SortColumn { name: "Err/Drop" },
+    SortColumn { name: "Status" },
+];
+
+pub const DEFAULT_SORT: TabSortState = TabSortState {
+    column: 0,
+    ascending: true,
+};
+
+// serves both Dashboard and Interfaces tabs — column name aliases
+// like "Interface"/"Name" and "IP Address"/"IPv4" handle the overlap
+pub fn sort_interfaces(
+    interfaces: &mut [crate::collectors::traffic::InterfaceTraffic],
+    tab: Tab,
+    column: usize,
+    ascending: bool,
+    interface_info: &[crate::platform::InterfaceInfo],
+) {
+    let cols = sort_columns_for_tab(tab);
+    let col_name = cols.get(column).map(|c| c.name).unwrap_or("");
+
+    interfaces.sort_by(|a, b| {
+        let info_a = interface_info.iter().find(|i| i.name == a.name);
+        let info_b = interface_info.iter().find(|i| i.name == b.name);
+        let ord = match col_name {
+            "Interface" | "Name" => cmp_case_insensitive(&a.name, &b.name),
+            "IP Address" | "IPv4" => {
+                let ip_a = info_a.and_then(|i| i.ipv4.as_deref()).unwrap_or("");
+                let ip_b = info_b.and_then(|i| i.ipv4.as_deref()).unwrap_or("");
+                cmp_ip(ip_a, ip_b)
+            }
+            "IPv6" => {
+                let ip_a = info_a.and_then(|i| i.ipv6.as_deref()).unwrap_or("");
+                let ip_b = info_b.and_then(|i| i.ipv6.as_deref()).unwrap_or("");
+                cmp_ip(ip_a, ip_b)
+            }
+            "MAC" => {
+                let mac_a = info_a.and_then(|i| i.mac.as_deref()).unwrap_or("");
+                let mac_b = info_b.and_then(|i| i.mac.as_deref()).unwrap_or("");
+                cmp_case_insensitive(mac_a, mac_b)
+            }
+            "MTU" => {
+                let mtu_a = info_a.and_then(|i| i.mtu).unwrap_or(0);
+                let mtu_b = info_b.and_then(|i| i.mtu).unwrap_or(0);
+                mtu_a.cmp(&mtu_b)
+            }
+            "RX B/s" | "Rx Rate" => cmp_f64(a.rx_rate, b.rx_rate),
+            "TX B/s" | "Tx Rate" => cmp_f64(a.tx_rate, b.tx_rate),
+            "Rx Total" => a.rx_bytes_total.cmp(&b.rx_bytes_total),
+            "Tx Total" => a.tx_bytes_total.cmp(&b.tx_bytes_total),
+            "RX Pkts" | "Rx Packets" => a.rx_packets.cmp(&b.rx_packets),
+            "TX Pkts" | "Tx Packets" => a.tx_packets.cmp(&b.tx_packets),
+            "Err/Drop" | "Errors/Drop" => {
+                let err_a = a.rx_errors + a.tx_errors + a.rx_drops + a.tx_drops;
+                let err_b = b.rx_errors + b.tx_errors + b.rx_drops + b.tx_drops;
+                err_a.cmp(&err_b)
+            }
+            "Status" => {
+                let up_a = info_a.map(|i| i.is_up).unwrap_or(false);
+                let up_b = info_b.map(|i| i.is_up).unwrap_or(false);
+                up_a.cmp(&up_b)
+            }
+            _ => std::cmp::Ordering::Equal,
+        };
+        apply_direction(ord, ascending)
+    });
+}
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let chunks = Layout::default()
@@ -16,9 +97,23 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         ])
         .split(area);
 
+    // sort interfaces once, share between table and sparkline so
+    // selected_interface index refers to the same sorted order
+    let mut sorted_interfaces = app.traffic.interfaces();
+    let sort_state = app.sort_states.get(&crate::app::Tab::Interfaces);
+    if let Some(state) = sort_state {
+        sort_interfaces(
+            &mut sorted_interfaces,
+            crate::app::Tab::Interfaces,
+            state.column,
+            state.ascending,
+            &app.interface_info,
+        );
+    }
+
     render_header(f, app, chunks[0]);
-    render_detail_table(f, app, chunks[1]);
-    render_sparkline(f, app, chunks[2]);
+    render_detail_table(f, app, &sorted_interfaces, chunks[1]);
+    render_sparkline(f, app, &sorted_interfaces, chunks[2]);
     render_footer(f, app, chunks[3]);
 }
 
@@ -26,23 +121,16 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
     widgets::render_header(f, app, area);
 }
 
-fn render_detail_table(f: &mut Frame, app: &App, area: Rect) {
-    let header = Row::new(vec![
-        Cell::from("Name").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("IPv4").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("IPv6").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("MAC").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("MTU").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("RX B/s").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("TX B/s").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("RX Pkts").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("TX Pkts").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("Err/Drop").style(Style::default().fg(Color::Cyan).bold()),
-        Cell::from("Status").style(Style::default().fg(Color::Cyan).bold()),
-    ])
-    .height(1);
+fn render_detail_table(
+    f: &mut Frame,
+    app: &App,
+    interfaces: &[crate::collectors::traffic::InterfaceTraffic],
+    area: Rect,
+) {
+    let tab = crate::app::Tab::Interfaces;
 
-    let interfaces = app.traffic.interfaces();
+    let header = widgets::sort_header_row(app, tab, COLUMNS);
+
     let rows: Vec<Row> = interfaces
         .iter()
         .enumerate()
@@ -74,13 +162,13 @@ fn render_detail_table(f: &mut Frame, app: &App, area: Rect) {
             );
 
             let status_style = if is_up {
-                Style::default().fg(Color::Green)
+                Style::default().fg(app.theme.status_good)
             } else {
-                Style::default().fg(Color::Red)
+                Style::default().fg(app.theme.status_error)
             };
 
             let row_style = if app.selected_interface == Some(i) {
-                Style::default().bg(Color::Rgb(40, 40, 60))
+                Style::default().bg(app.theme.selection_bg)
             } else {
                 Style::default()
             };
@@ -92,9 +180,9 @@ fn render_detail_table(f: &mut Frame, app: &App, area: Rect) {
                 Cell::from(mac),
                 Cell::from(mtu),
                 Cell::from(widgets::format_bytes_rate_padded(iface.rx_rate))
-                    .style(Style::default().fg(Color::Green)),
+                    .style(Style::default().fg(app.theme.rx_rate)),
                 Cell::from(widgets::format_bytes_rate_padded(iface.tx_rate))
-                    .style(Style::default().fg(Color::Blue)),
+                    .style(Style::default().fg(app.theme.tx_rate)),
                 Cell::from(iface.rx_packets.to_string()),
                 Cell::from(iface.tx_packets.to_string()),
                 Cell::from(errors_drops),
@@ -125,16 +213,22 @@ fn render_detail_table(f: &mut Frame, app: &App, area: Rect) {
         Block::default()
             .title(" Interface Details ")
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::DarkGray)),
+            .border_style(Style::default().fg(app.theme.border)),
     );
 
     f.render_widget(table, area);
 }
 
-fn render_sparkline(f: &mut Frame, app: &App, area: Rect) {
+fn render_sparkline(
+    f: &mut Frame,
+    app: &App,
+    sorted_interfaces: &[crate::collectors::traffic::InterfaceTraffic],
+    area: Rect,
+) {
+    // look up from the sorted list so the sparkline matches the highlighted row
     let selected = app
         .selected_interface
-        .and_then(|i| app.traffic.interface_at(i));
+        .and_then(|i| sorted_interfaces.get(i));
 
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -147,20 +241,20 @@ fn render_sparkline(f: &mut Frame, app: &App, area: Rect) {
                 Block::default()
                     .title(format!(" RX {} ", iface.name))
                     .borders(Borders::ALL)
-                    .border_style(Style::default().fg(Color::DarkGray)),
+                    .border_style(Style::default().fg(app.theme.border)),
             )
             .data(iface.rx_history.as_slices().0)
-            .style(Style::default().fg(Color::Green));
+            .style(Style::default().fg(app.theme.rx_rate));
 
         let tx_spark = Sparkline::default()
             .block(
                 Block::default()
                     .title(format!(" TX {} ", iface.name))
                     .borders(Borders::ALL)
-                    .border_style(Style::default().fg(Color::DarkGray)),
+                    .border_style(Style::default().fg(app.theme.border)),
             )
             .data(iface.tx_history.as_slices().0)
-            .style(Style::default().fg(Color::Blue));
+            .style(Style::default().fg(app.theme.tx_rate));
 
         f.render_widget(rx_spark, chunks[0]);
         f.render_widget(tx_spark, chunks[1]);
@@ -168,7 +262,7 @@ fn render_sparkline(f: &mut Frame, app: &App, area: Rect) {
         let empty = Paragraph::new("No interface selected").block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::DarkGray)),
+                .border_style(Style::default().fg(app.theme.border)),
         );
         f.render_widget(empty, area);
     }
@@ -176,11 +270,13 @@ fn render_sparkline(f: &mut Frame, app: &App, area: Rect) {
 
 fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     let hints = vec![
-        Span::styled("a", Style::default().fg(Color::Yellow).bold()),
+        Span::styled("s", Style::default().fg(app.theme.key_hint).bold()),
+        Span::raw(":Sort  "),
+        Span::styled("a", Style::default().fg(app.theme.key_hint).bold()),
         Span::raw(":Analyze  "),
-        Span::styled("p", Style::default().fg(Color::Yellow).bold()),
+        Span::styled("p", Style::default().fg(app.theme.key_hint).bold()),
         Span::raw(":Pause  "),
-        Span::styled("r", Style::default().fg(Color::Yellow).bold()),
+        Span::styled("r", Style::default().fg(app.theme.key_hint).bold()),
         Span::raw(":Refresh"),
     ];
     widgets::render_footer(f, app, area, hints);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,6 +6,7 @@ pub mod interfaces;
 pub mod packets;
 pub mod processes;
 pub mod settings;
+pub mod sort_picker;
 pub mod stats;
 pub mod timeline;
 pub mod topology;

--- a/src/ui/processes.rs
+++ b/src/ui/processes.rs
@@ -1,9 +1,51 @@
 use crate::app::App;
+use crate::sort::{apply_direction, cmp_case_insensitive, cmp_f64, SortColumn};
 use crate::ui::widgets;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Cell, Row, Table},
 };
+
+use crate::sort::TabSortState;
+
+pub const COLUMNS: &[SortColumn] = &[
+    SortColumn { name: "Process" },
+    SortColumn { name: "PID" },
+    SortColumn { name: "Conns" },
+    SortColumn { name: "Rx Rate" },
+    SortColumn { name: "Tx Rate" },
+    SortColumn { name: "Total Rate" },
+    SortColumn { name: "Rx Total" },
+    SortColumn { name: "Tx Total" },
+];
+
+// top bandwidth first — matches prior behavior before sort picker
+pub const DEFAULT_SORT: TabSortState = TabSortState {
+    column: 5, // "Total Rate"
+    ascending: false,
+};
+
+pub fn sort(
+    procs: &mut [crate::collectors::process_bandwidth::ProcessBandwidth],
+    column: usize,
+    ascending: bool,
+) {
+    let col_name = COLUMNS.get(column).map(|c| c.name).unwrap_or("");
+    procs.sort_by(|a, b| {
+        let ord = match col_name {
+            "Process" => cmp_case_insensitive(&a.process_name, &b.process_name),
+            "PID" => a.pid.cmp(&b.pid),
+            "Conns" => a.connection_count.cmp(&b.connection_count),
+            "Rx Rate" => cmp_f64(a.rx_rate, b.rx_rate),
+            "Tx Rate" => cmp_f64(a.tx_rate, b.tx_rate),
+            "Total Rate" => cmp_f64(a.rx_rate + a.tx_rate, b.rx_rate + b.tx_rate),
+            "Rx Total" => a.rx_bytes.cmp(&b.rx_bytes),
+            "Tx Total" => a.tx_bytes.cmp(&b.tx_bytes),
+            _ => std::cmp::Ordering::Equal,
+        };
+        apply_direction(ord, ascending)
+    });
+}
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let layout = widgets::frame_layout(area);
@@ -25,19 +67,15 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_process_table(f: &mut Frame, app: &App, area: Rect) {
-    let header = Row::new(vec![
-        Cell::from("Process").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("PID").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("Conns").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("RX Rate").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("TX Rate").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("Total Rate").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("RX Total").style(Style::default().fg(app.theme.brand).bold()),
-        Cell::from("TX Total").style(Style::default().fg(app.theme.brand).bold()),
-    ])
-    .height(1);
+    let tab = crate::app::Tab::Processes;
 
-    let ranked = app.process_bandwidth.ranked();
+    let header = widgets::sort_header_row(app, tab, COLUMNS);
+
+    let mut ranked = app.process_bandwidth.ranked().to_vec();
+    let sort_state = app.sort_states.get(&crate::app::Tab::Processes);
+    if let Some(state) = sort_state {
+        sort(&mut ranked, state.column, state.ascending);
+    }
     let visible_rows = area.height.saturating_sub(3) as usize;
     let scroll = app
         .scroll
@@ -107,6 +145,8 @@ fn render_process_table(f: &mut Frame, app: &App, area: Rect) {
 
 fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     let hints = vec![
+        Span::styled("s", Style::default().fg(app.theme.key_hint).bold()),
+        Span::raw(":Sort  "),
         Span::styled("e", Style::default().fg(app.theme.key_hint).bold()),
         Span::raw(":Export  "),
         Span::styled("Enter", Style::default().fg(app.theme.key_hint).bold()),

--- a/src/ui/sort_picker.rs
+++ b/src/ui/sort_picker.rs
@@ -1,0 +1,386 @@
+use crate::sort::{SortColumn, TabSortState};
+use crate::theme::Theme;
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+// -- state --
+
+#[derive(Default)]
+pub struct SortPickerState {
+    open: bool,
+    cursor: usize,
+    filter: String,
+    filtering: bool,
+}
+
+impl SortPickerState {
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+}
+
+// -- actions returned to the caller --
+
+pub enum PickerAction {
+    None,
+    Select(usize),
+    ToggleDirection,
+    Close,
+}
+
+impl SortPickerState {
+    pub fn open(&mut self, current_column: usize, column_count: usize) {
+        self.cursor = if column_count > 0 {
+            current_column.min(column_count - 1)
+        } else {
+            0
+        };
+        self.filter.clear();
+        self.filtering = false;
+        self.open = true;
+    }
+
+    pub fn close(&mut self) {
+        self.open = false;
+        self.filter.clear();
+        self.filtering = false;
+    }
+
+    pub fn filtered_columns<'a>(&self, columns: &'a [SortColumn]) -> Vec<(usize, &'a str)> {
+        if self.filter.is_empty() {
+            columns
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i, c.name))
+                .collect()
+        } else {
+            let needle = self.filter.to_lowercase();
+            columns
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| c.name.to_lowercase().contains(&needle))
+                .map(|(i, c)| (i, c.name))
+                .collect()
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent, columns: &[SortColumn]) -> PickerAction {
+        let filtered = self.filtered_columns(columns);
+        let count = filtered.len().max(1);
+
+        // clamp cursor after filter changes may have shrunk the list
+        if self.cursor >= count {
+            self.cursor = count.saturating_sub(1);
+        }
+
+        if self.filtering {
+            match key.code {
+                KeyCode::Esc => {
+                    self.filter.clear();
+                    self.filtering = false;
+                    self.cursor = 0;
+                }
+                KeyCode::Enter => {
+                    self.filtering = false;
+                    self.cursor = 0;
+                }
+                KeyCode::Backspace => {
+                    self.filter.pop();
+                    self.cursor = 0;
+                }
+                KeyCode::Char(c) => {
+                    self.filter.push(c);
+                    self.cursor = 0;
+                }
+                _ => {}
+            }
+            return PickerAction::None;
+        }
+
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('s') | KeyCode::Char('q') => {
+                self.close();
+                PickerAction::Close
+            }
+            KeyCode::Char('/') => {
+                self.filtering = true;
+                self.filter.clear();
+                self.cursor = 0;
+                PickerAction::None
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.cursor = (self.cursor + 1) % count;
+                PickerAction::None
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.cursor = (self.cursor + count - 1) % count;
+                PickerAction::None
+            }
+            KeyCode::Enter => {
+                if let Some((col_idx, _)) = filtered.get(self.cursor) {
+                    let idx = *col_idx;
+                    self.close();
+                    PickerAction::Select(idx)
+                } else {
+                    PickerAction::None
+                }
+            }
+            KeyCode::Char('S') => PickerAction::ToggleDirection,
+            _ => PickerAction::None,
+        }
+    }
+}
+
+// -- rendering --
+
+pub fn render(
+    f: &mut Frame,
+    state: &SortPickerState,
+    columns: &[SortColumn],
+    current_sort: Option<&TabSortState>,
+    theme: &Theme,
+    area: Rect,
+) {
+    if columns.is_empty() {
+        return;
+    }
+
+    let filtered = state.filtered_columns(columns);
+
+    let has_filter = state.filtering || !state.filter.is_empty();
+    let filter_line_height = if has_filter { 1u16 } else { 0 };
+    let row_count = filtered.len() as u16;
+    let popup_height = (row_count + 4 + filter_line_height).min(area.height.saturating_sub(4));
+    let popup_width = 30u16.min(area.width.saturating_sub(4));
+
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup = Rect::new(x, y, popup_width, popup_height);
+
+    f.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title(" Sort by ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.brand));
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+
+    let current_col = current_sort.map(|s| s.column);
+    let ascending = current_sort.map(|s| s.ascending).unwrap_or(true);
+
+    let content_y = if has_filter {
+        let filter_text = if state.filtering {
+            format!("/{}_", state.filter)
+        } else {
+            format!("/{}", state.filter)
+        };
+        let filter_line = Paragraph::new(Line::from(vec![Span::styled(
+            filter_text,
+            Style::default().fg(theme.key_hint),
+        )]));
+        f.render_widget(filter_line, Rect::new(inner.x, inner.y, inner.width, 1));
+        inner.y + 1
+    } else {
+        inner.y
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (list_idx, (orig_idx, label)) in filtered.iter().enumerate() {
+        let is_highlighted = list_idx == state.cursor;
+        let is_active = current_col == Some(*orig_idx);
+
+        let marker = if is_highlighted { "▶ " } else { "  " };
+        let direction = if is_active {
+            if ascending {
+                " ▲"
+            } else {
+                " ▼"
+            }
+        } else {
+            ""
+        };
+
+        let style = if is_highlighted {
+            Style::default().fg(theme.active_tab).bold()
+        } else if is_active {
+            Style::default().fg(theme.text_primary).bold()
+        } else {
+            Style::default().fg(theme.text_muted)
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(marker, style),
+            Span::styled(format!("{label}{direction}"), style),
+        ]));
+    }
+
+    if filtered.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (no matches)",
+            Style::default().fg(theme.text_muted).italic(),
+        )));
+    }
+
+    let content_height = (inner.y + inner.height.saturating_sub(1)).saturating_sub(content_y);
+    let content = Paragraph::new(lines);
+    f.render_widget(
+        content,
+        Rect::new(inner.x, content_y, inner.width, content_height),
+    );
+
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled("↑↓", Style::default().fg(theme.key_hint).bold()),
+        Span::raw(":Move "),
+        Span::styled("S", Style::default().fg(theme.key_hint).bold()),
+        Span::raw(":Dir "),
+        Span::styled("/", Style::default().fg(theme.key_hint).bold()),
+        Span::raw(":Find "),
+        Span::styled("Enter", Style::default().fg(theme.key_hint).bold()),
+        Span::raw(":Ok "),
+        Span::styled("Esc", Style::default().fg(theme.key_hint).bold()),
+        Span::raw(":Cancel"),
+    ]))
+    .alignment(Alignment::Center);
+    let footer_area = Rect::new(
+        inner.x,
+        inner.y + inner.height.saturating_sub(1),
+        inner.width,
+        1,
+    );
+    f.render_widget(footer, footer_area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn cols() -> &'static [SortColumn] {
+        &[
+            SortColumn { name: "Alpha" },
+            SortColumn { name: "Beta" },
+            SortColumn { name: "Gamma" },
+        ]
+    }
+
+    #[test]
+    fn cursor_wraps_forward() {
+        let mut state = SortPickerState::default();
+        state.open(0, 3);
+        state.handle_key(key(KeyCode::Char('j')), cols());
+        assert_eq!(state.cursor, 1);
+        state.handle_key(key(KeyCode::Char('j')), cols());
+        assert_eq!(state.cursor, 2);
+        state.handle_key(key(KeyCode::Char('j')), cols());
+        assert_eq!(state.cursor, 0); // wrapped
+    }
+
+    #[test]
+    fn cursor_wraps_backward() {
+        let mut state = SortPickerState::default();
+        state.open(0, 3);
+        state.handle_key(key(KeyCode::Char('k')), cols());
+        assert_eq!(state.cursor, 2); // wrapped to end
+    }
+
+    #[test]
+    fn enter_returns_select_with_column_index() {
+        let mut state = SortPickerState::default();
+        state.open(0, 3);
+        state.handle_key(key(KeyCode::Down), cols());
+        let action = state.handle_key(key(KeyCode::Enter), cols());
+        assert!(matches!(action, PickerAction::Select(1)));
+        assert!(!state.is_open()); // closed after select
+    }
+
+    #[test]
+    fn esc_returns_close() {
+        let mut state = SortPickerState::default();
+        state.open(0, 3);
+        let action = state.handle_key(key(KeyCode::Esc), cols());
+        assert!(matches!(action, PickerAction::Close));
+        assert!(!state.is_open());
+    }
+
+    #[test]
+    fn shift_s_returns_toggle_direction() {
+        let mut state = SortPickerState::default();
+        state.open(0, 3);
+        let action = state.handle_key(key(KeyCode::Char('S')), cols());
+        assert!(matches!(action, PickerAction::ToggleDirection));
+    }
+
+    #[test]
+    fn filter_narrows_results() {
+        let mut state = SortPickerState::default();
+        state.open(0, 3);
+        // enter filter mode
+        state.handle_key(key(KeyCode::Char('/')), cols());
+        assert!(state.filtering);
+        // type "bet"
+        state.handle_key(key(KeyCode::Char('b')), cols());
+        state.handle_key(key(KeyCode::Char('e')), cols());
+        state.handle_key(key(KeyCode::Char('t')), cols());
+        let filtered = state.filtered_columns(cols());
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].1, "Beta");
+        // original index preserved
+        assert_eq!(filtered[0].0, 1);
+    }
+
+    #[test]
+    fn filter_esc_clears_filter() {
+        let mut state = SortPickerState::default();
+        state.open(0, 3);
+        state.handle_key(key(KeyCode::Char('/')), cols());
+        state.handle_key(key(KeyCode::Char('x')), cols());
+        state.handle_key(key(KeyCode::Esc), cols());
+        assert!(!state.filtering);
+        assert!(state.filter.is_empty());
+    }
+
+    #[test]
+    fn open_resets_state() {
+        let mut state = SortPickerState::default();
+        state.open(2, 3);
+        // mutate state
+        state.cursor = 5;
+        state.filter = "old".into();
+        state.filtering = true;
+        // reopen should reset
+        state.open(2, 3);
+        assert_eq!(state.cursor, 2);
+        assert!(state.filter.is_empty());
+        assert!(!state.filtering);
+        assert!(state.is_open());
+    }
+
+    #[test]
+    fn open_clamps_cursor_to_column_count() {
+        let mut state = SortPickerState::default();
+        state.open(10, 3);
+        assert_eq!(state.cursor, 2); // clamped to last column
+    }
+
+    #[test]
+    fn cursor_clamped_after_filter_shrinks_list() {
+        let mut state = SortPickerState::default();
+        // open at cursor 2 (Gamma), then filter to only "Alpha"
+        // — cursor 2 is now out of bounds
+        state.open(2, 3);
+        state.handle_key(key(KeyCode::Char('/')), cols());
+        state.handle_key(key(KeyCode::Char('a')), cols());
+        state.handle_key(key(KeyCode::Enter), cols());
+        // next key press should clamp cursor
+        state.handle_key(key(KeyCode::Char('j')), cols());
+        assert!(state.cursor < state.filtered_columns(cols()).len());
+    }
+}

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -2,7 +2,7 @@ use crate::app::{App, Tab};
 use crate::collectors::incident::RecorderState;
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Cell, Paragraph, Row},
 };
 
 /// Standard 3-chunk vertical layout used by most tabs: header / content / footer.
@@ -245,6 +245,21 @@ pub fn tab_at_column(col: u16, insights_enabled: bool) -> Option<Tab> {
         x += label_len;
     }
     None
+}
+
+/// Build a table header row from a tab's COLUMNS array with sort indicators.
+pub fn sort_header_row(app: &App, tab: Tab, columns: &[crate::sort::SortColumn]) -> Row<'static> {
+    Row::new(
+        columns
+            .iter()
+            .enumerate()
+            .map(|(i, col)| {
+                Cell::from(format!("{}{}", col.name, app.sort_indicator(tab, i)))
+                    .style(Style::default().fg(app.theme.brand).bold())
+            })
+            .collect::<Vec<_>>(),
+    )
+    .height(1)
 }
 
 pub fn render_footer(f: &mut Frame, app: &App, area: Rect, context_hints: Vec<Span<'static>>) {


### PR DESCRIPTION
## Summary [2/3]

Wires up the sort infrastructure from [1/3] into the existing codebase.

- **Per-tab colocated `COLUMNS` + `DEFAULT_SORT` + sort functions** in `connections.rs`, `dashboard.rs`, `interfaces.rs`, `processes.rs`
- **Shared `sort_header_row()`** helper in `widgets.rs` eliminates header generation duplication
- **Sort picker integration** in `app.rs` key handler with auto-close on non-sortable tab switch
- **Help menu** updated with sort picker section documenting all controls
- **Footer hints** — all sortable tabs show `s:Sort`
- Dashboard and Interfaces sort once at `render()` level, passing sorted list to both table and sparkline to prevent index mismatch

> **Review order:** Review matthart1983/netwatch#20 first, then this PR. Merge in order: [1/3] → [2/3] → [3/3].

This is part 2 of a 3-part stacked PR:
- [1/3] Sort infrastructure + picker → matthart1983/netwatch#20
- **[2/3] Wire up sorting across tabs** (this PR)
- [3/3] Comprehensive sort tests

## Test plan
- [x] `cargo test` passes
- [x] Sort indicators (▲/▼) visible on all 4 table tabs
- [x] `s` opens picker, `j`/`k`/arrows navigate, `Enter` selects, `S` toggles direction, `/` filters
- [x] Picker auto-closes on tab switch to non-sortable tab
- [x] Processes defaults to Total Rate descending