### PR TITLE
feat(keys): vim-style hjkl navigation (closes #18)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1066,10 +1066,10 @@ fn handle_help_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
             app.show_help = false;
             app.scroll.help_scroll = 0;
         }
-        KeyCode::Up => {
+        KeyCode::Up | KeyCode::Char('k') => {
             app.scroll.help_scroll = app.scroll.help_scroll.saturating_sub(1);
         }
-        KeyCode::Down => {
+        KeyCode::Down | KeyCode::Char('j') => {
             app.scroll.help_scroll += 1;
         }
         KeyCode::Char('q') => return true,
@@ -1133,15 +1133,15 @@ fn handle_settings_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
                 app.show_settings = false;
             }
             KeyCode::Char('q') => return true,
-            KeyCode::Up => {
+            KeyCode::Up | KeyCode::Char('k') => {
                 app.settings_cursor = app.settings_cursor.saturating_sub(1);
             }
-            KeyCode::Down => {
+            KeyCode::Down | KeyCode::Char('j') => {
                 if app.settings_cursor + 1 < ui::settings::SETTINGS_COUNT {
                     app.settings_cursor += 1;
                 }
             }
-            KeyCode::Left | KeyCode::Right
+            KeyCode::Left | KeyCode::Right | KeyCode::Char('h') | KeyCode::Char('l')
                 if app.settings_cursor == ui::settings::cursor::THEME =>
             {
                 let names = crate::theme::THEME_NAMES;
@@ -1149,7 +1149,8 @@ fn handle_settings_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
                     .iter()
                     .position(|&n| n == app.user_config.theme)
                     .unwrap_or(0);
-                let next = if key.code == KeyCode::Right {
+                let forward = matches!(key.code, KeyCode::Right | KeyCode::Char('l'));
+                let next = if forward {
                     (current + 1) % names.len()
                 } else {
                     (current + names.len() - 1) % names.len()
@@ -1159,7 +1160,7 @@ fn handle_settings_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
                 app.settings_status = Some(format!("Theme: {}", names[next]));
                 app.settings_status_tick = 0;
             }
-            KeyCode::Left | KeyCode::Right
+            KeyCode::Left | KeyCode::Right | KeyCode::Char('h') | KeyCode::Char('l')
                 if app.settings_cursor == ui::settings::cursor::DEFAULT_TAB =>
             {
                 let names = ui::settings::TAB_NAMES;
@@ -1167,7 +1168,8 @@ fn handle_settings_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
                     .iter()
                     .position(|&n| n == app.user_config.default_tab)
                     .unwrap_or(0);
-                let next = if key.code == KeyCode::Right {
+                let forward = matches!(key.code, KeyCode::Right | KeyCode::Char('l'));
+                let next = if forward {
                     (current + 1) % names.len()
                 } else {
                     (current + names.len() - 1) % names.len()
@@ -1349,10 +1351,14 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
         KeyCode::Left if app.current_tab == Tab::Packets && app.stream_view_open => {
             app.stream_direction_filter = StreamDirectionFilter::BtoA;
         }
-        KeyCode::Up if app.current_tab == Tab::Packets && app.stream_view_open => {
+        KeyCode::Up | KeyCode::Char('k')
+            if app.current_tab == Tab::Packets && app.stream_view_open =>
+        {
             app.scroll.stream_scroll = app.scroll.stream_scroll.saturating_sub(1);
         }
-        KeyCode::Down if app.current_tab == Tab::Packets && app.stream_view_open => {
+        KeyCode::Down | KeyCode::Char('j')
+            if app.current_tab == Tab::Packets && app.stream_view_open =>
+        {
             app.scroll.stream_scroll += 1;
         }
         KeyCode::Char('s') if app.current_tab == Tab::Packets && !app.stream_view_open => {
@@ -1636,8 +1642,8 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
                 }
             }
         }
-        KeyCode::Up => scroll_tab(app, -1),
-        KeyCode::Down => scroll_tab(app, 1),
+        KeyCode::Up | KeyCode::Char('k') => scroll_tab(app, -1),
+        KeyCode::Down | KeyCode::Char('j') => scroll_tab(app, 1),
         KeyCode::PageUp => scroll_tab(app, -(PAGE_SCROLL as isize)),
         KeyCode::PageDown => scroll_tab(app, PAGE_SCROLL as isize),
         KeyCode::Char('/') if app.current_tab == Tab::Packets && !app.stream_view_open => {

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -104,13 +104,16 @@ fn build_help_lines() -> Vec<Line<'static>> {
         "t",
         "Cycle theme (dark/light/solarized/dracula/nord)",
     ));
-    lines.push(key_line(",", "Open settings menu (←→ to cycle theme)"));
+    lines.push(key_line(
+        ",",
+        "Open settings menu (←→ / h/l to cycle theme)",
+    ));
     lines.push(key_line("PgUp/PgDn", "Scroll lists by a page"));
     lines.push(Line::raw(""));
 
     // DASHBOARD
     lines.push(section_header("DASHBOARD (Tab 1)"));
-    lines.push(key_line("↑↓", "Select interface"));
+    lines.push(key_line("↑↓ / j/k", "Select interface"));
     lines.push(key_line("s", "Open sort picker"));
     lines.push(Line::raw(""));
 
@@ -125,7 +128,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
 
     // CONNECTIONS
     lines.push(section_header("CONNECTIONS (Tab 2)"));
-    lines.push(key_line("↑↓", "Scroll connection list"));
+    lines.push(key_line("↑↓ / j/k", "Scroll connection list"));
     lines.push(key_line("s", "Open sort picker"));
     lines.push(key_line(
         "/",
@@ -149,13 +152,13 @@ fn build_help_lines() -> Vec<Line<'static>> {
 
     // INTERFACES
     lines.push(section_header("INTERFACES (Tab 3)"));
-    lines.push(key_line("↑↓", "Select interface"));
+    lines.push(key_line("↑↓ / j/k", "Select interface"));
     lines.push(key_line("s", "Open sort picker"));
     lines.push(Line::raw(""));
 
     // PACKETS
     lines.push(section_header("PACKETS (Tab 4)"));
-    lines.push(key_line("↑↓", "Scroll packet list"));
+    lines.push(key_line("↑↓ / j/k", "Scroll packet list"));
     lines.push(key_line("Enter", "Select packet at cursor"));
     lines.push(key_line("c", "Start/stop capture"));
     lines.push(key_line(
@@ -181,7 +184,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
     // STREAM VIEW
     lines.push(section_header("STREAM VIEW (in Packets tab)"));
     lines.push(key_line("Esc", "Close stream view"));
-    lines.push(key_line("↑↓", "Scroll stream content"));
+    lines.push(key_line("↑↓ / j/k", "Scroll stream content"));
     lines.push(key_line("→←", "Filter direction (A→B / B→A)"));
     lines.push(key_line("a", "Show both directions"));
     lines.push(key_line("h", "Toggle hex/text mode"));
@@ -189,12 +192,12 @@ fn build_help_lines() -> Vec<Line<'static>> {
 
     // STATS
     lines.push(section_header("STATS (Tab 5)"));
-    lines.push(key_line("↑↓", "Scroll protocol list"));
+    lines.push(key_line("↑↓ / j/k", "Scroll protocol list"));
     lines.push(Line::raw(""));
 
     // TOPOLOGY
     lines.push(section_header("TOPOLOGY (Tab 6)"));
-    lines.push(key_line("↑↓", "Scroll topology view"));
+    lines.push(key_line("↑↓ / j/k", "Scroll topology view"));
     lines.push(key_line("Enter", "Jump to Connections tab"));
     lines.push(key_line("T", "Traceroute to selected remote host"));
     lines.push(key_line("Esc", "Close traceroute overlay"));
@@ -202,14 +205,14 @@ fn build_help_lines() -> Vec<Line<'static>> {
 
     // TIMELINE
     lines.push(section_header("TIMELINE (Tab 7)"));
-    lines.push(key_line("↑↓", "Scroll connection list"));
+    lines.push(key_line("↑↓ / j/k", "Scroll connection list"));
     lines.push(key_line("t", "Cycle time window (1m/5m/15m/30m/1h)"));
     lines.push(key_line("Enter", "Jump to Connections tab"));
     lines.push(Line::raw(""));
 
     // PROCESSES
     lines.push(section_header("PROCESSES (Tab 8)"));
-    lines.push(key_line("↑↓", "Scroll process list"));
+    lines.push(key_line("↑↓ / j/k", "Scroll process list"));
     lines.push(key_line("s", "Open sort picker"));
     lines.push(key_line("e", "Export connections to JSON + CSV"));
     lines.push(Line::raw(""));


### PR DESCRIPTION
## Summary
- `j`/`k` alias `Down`/`Up` for list/stream/help/settings navigation
- `h`/`l` alias `Left`/`Right` for settings theme + default-tab selectors
- Help overlay updated to show both arrow and hjkl bindings

## Scope notes
- Stream view's existing `h` (toggle hex/text mode) is preserved — it's context-gated to `Packets + stream_view_open` so there's no conflict with `h`-as-left in other contexts.
- Stream view Left/Right (direction filter A→B / B→A) intentionally NOT aliased to hjkl — would collide with the hex toggle.
- Tab switching (1-8) is unchanged; didn't add h/l for tab cycling since the repo convention is number keys.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 264 passed
- [x] `cargo clippy -- -W clippy::all` — zero new warnings (9 pre-existing on main)
- [ ] Smoke test in a live terminal: j/k scroll each tab, h/l cycle theme/default-tab in settings, stream view `h` still toggles hex mode