### PR TITLE
docs: remove all competitor (rustnet/bandwhich) references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,13 +134,12 @@ LAN / IoT / ops protocols that previously rendered as generic "TCP" /
 
 ### Notes
 
-This closes the `DPI protocol breadth` row on the netwatch-vs-rustnet
-comparison that's been red since rustnet shipped its long-tail. After
-v0.20.0 netwatch has 13 shipped classifiers (TLS / QUIC with Initial
-decrypt / DNS / HTTP / SSH / MQTT / STUN / BitTorrent / NetBIOS /
-SNMP / SSDP / FTP / LLMNR) + IGMP at the IP layer + 25 port labels.
-rustnet has 17 stream classifiers; netwatch covers all the operationally
-common ones plus the QUIC depth (Initial decryption) rustnet doesn't.
+This substantially broadens DPI protocol breadth. After v0.20.0 netwatch
+has 13 shipped classifiers (TLS / QUIC with Initial decrypt / DNS / HTTP /
+SSH / MQTT / STUN / BitTorrent / NetBIOS / SNMP / SSDP / FTP / LLMNR) +
+IGMP at the IP layer + 25 port labels — covering the operationally common
+protocols, plus QUIC Initial-decryption depth that most terminal tools
+don't attempt.
 
 37 new unit tests across the 8 classifier files cover the success
 case, the rejection of look-alike traffic (HTTP on FTP port, garbage
@@ -163,7 +162,7 @@ non-CONNECT MQTT, v1 vs v2c SNMP, M-SEARCH vs NOTIFY SSDP).
 - `Connection` struct gained `retransmits: u32` and `out_of_order: u32` fields, sourced from a new `StreamTracker::snapshot_anomalies()` snapshot during the connection collector's update tick. Both default to 0 via `#[serde(default)]` so on-disk Flight Recorder bundles and stored configs remain forward-compatible.
 
 ### Notes
-This closes the `TCP retransmits / out-of-order analytics` row on the netwatch-vs-rustnet matrix that's been red since the May snapshots. Combined with the v0.18.x sandbox arc, netwatch's defensible-edge picture vs. rustnet narrows the rustnet column to: DPI long-tail (MQTT/BitTorrent/SNMP/…), smart staleness coloring, Windows+FreeBSD native process attribution, and distribution breadth.
+This adds per-stream TCP retransmit / out-of-order analytics — health signals that previously meant dropping to a full packet analyzer. Combined with the v0.18.x sandbox arc, it strengthens netwatch's live-forensics edge; remaining areas to grow are DPI long-tail breadth (MQTT/BitTorrent/SNMP/…), smart staleness coloring, Windows/FreeBSD native process attribution, and distribution breadth.
 
 ## [0.18.1] - 2026-05-23
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,11 @@ Most terminal network tools stop at *"which process is using bandwidth."* NetWat
 
 **No config files. No setup. No flags required.**
 
-## Why not just `tshark` or `rustnet`?
+## Live forensics, not just monitoring
 
-You probably already have them. Here's where NetWatch fits between them:
+Most terminal network tools answer one question — *"which process is using bandwidth?"* — and stop. Full packet analyzers answer *"what happened?"*, but offline, after the fact, in a heavyweight GUI.
 
-- **vs `tshark` / Wireshark** — those are pcap *surgery*: powerful, but offline and after the fact. NetWatch is live *triage* — decode, fingerprint, detect, and freeze an evidence bundle in the moment an incident happens, without dropping to a three-pane GUI.
-- **vs `rustnet` / `bandwhich`** — those show you *what's on* the wire. NetWatch shows you *what's wrong with it*: decrypted payloads, JA4 fingerprints to pivot on, and background IDS detectors raising alerts. They're bandwidth meters; this is a forensics workbench.
+NetWatch lives in the gap: **live triage**. Decode L7 protocols, fingerprint clients with JA4, detect beaconing / port scans / DNS tunneling, and freeze an evidence bundle the moment an incident happens — in real time, in one terminal. A bandwidth meter tells you *what's on* the wire; NetWatch tells you *what's wrong with it*.
 
 ---
 

--- a/src/dpi/quic.rs
+++ b/src/dpi/quic.rs
@@ -418,7 +418,7 @@ fn reassemble_crypto(plaintext: &[u8]) -> Result<Vec<u8>, ()> {
 /// Decode one Initial packet into a human-readable frame breakdown.
 /// Returns lines like `"CRYPTO offset=0 len=1100"` or
 /// `"PADDING bytes=200"`. Used by the Packets tab's detail pane to
-/// surface the decrypted QUIC frame structure that rustnet/wireshark
+/// surface the decrypted QUIC frame structure that tools like Wireshark
 /// can't show without similar header-protection removal.
 pub fn decode_initial_frame_summary(payload: &[u8]) -> Option<Vec<String>> {
     let header = parse_long_header(payload)?;

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,7 +1,7 @@
 //! Security sandbox — restrict netwatch's authority after pcap + eBPF setup.
 //!
-//! Designed to mirror rustnet's three-OS approach (Landlock / Seatbelt /
-//! restricted token) but shipped in phases:
+//! A three-OS approach (Landlock / Seatbelt / restricted token),
+//! shipped in phases:
 //!
 //! - **Phase 1 (this module): Linux** — `caps` drop + `landlock` filesystem
 //!   and network restrictions. Applied after `ConnTracker::new()` returns


### PR DESCRIPTION
Removes every reference to competitor tools (rustnet, bandwhich) from public docs **and** source comments. Follows up #35, which introduced a "Why not just tshark or rustnet?" section — but the scope turned out larger: rustnet was also named in the CHANGELOG and two source files, predating that PR.

Naming rivals in your own docs mostly gives them oxygen, so this reframes the positioning by *category* instead — keeping all the strategic value without elevating anyone.

## Scope — all 4 files with references
- **README.md** — "Why not just `tshark` or `rustnet`?" → **"Live forensics, not just monitoring"**. Reframed around categories (full packet analyzers = offline/after-the-fact; bandwidth meters = what's-on-the-wire) vs NetWatch's live triage. No named competitors. Keeps the "what's on vs what's wrong" hook.
- **CHANGELOG.md** — two release notes (v0.19.0, v0.20.0) rewritten to describe the shipped capability directly instead of via a "netwatch-vs-rustnet comparison/matrix."
- **src/sandbox/mod.rs** — module doc no longer says the design "mirror[s] rustnet's three-OS approach" (comment-only).
- **src/dpi/quic.rs** — doc comment "rustnet/wireshark" → "tools like Wireshark" (comment-only).

## Notes
- `git grep -iE 'rustnet|bandwhich'` is now empty across all tracked files.
- `.rs` changes are comment-only — no behavior change, no build impact.
- Wireshark/tshark references are retained where they define the *category* (the README already brands itself "Wireshark's depth"); only the direct-competitor TUI tools were scrubbed. Say the word if you want those genericized too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)