### PR TITLE
netwatch v0.27.0: terminal theme + egress drift fixes + stable process identity

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -400,10 +400,15 @@ you can tell at a glance which path is live.
 
 ## Themes
 
-7 built-in themes with instant switching via `t`:
-**Dark** (default) · **Ocean** · **Solarized** · **Dracula** · **Nord** · **Sky** · **Paper**
+8 built-in themes with instant switching via `t`:
+**Dark** (default) · **Terminal** · **Ocean** · **Solarized** · **Dracula** · **Nord** · **Sky** · **Paper**
 
 Theme changes apply immediately. Persist them from the Settings overlay with `S`.
+
+**Terminal** pins no colors of its own — every slot resolves to an ANSI palette entry, and
+foreground and background use your terminal's own defaults. If you theme your whole desktop
+with pywal, matugen, or a terminal profile, this is the one that follows along. It's also
+accepted under the names `system` and `ansi` in a config file.
 
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -717,6 +717,7 @@ impl App {
         crate::graph::GraphOpts {
             fade: self.user_config.graph_fade,
             bg: self.theme.bg,
+            terminal_palette: self.theme.defers_to_terminal(),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1191,30 +1191,33 @@ impl App {
     }
 }
 
+/// Split `host:port` (in the form ss/lsof/netstat print) into its parts.
+///
+/// A missing part is `None` — including when it is *present but empty*, as in
+/// `":443"`. Returning `Some("")` there let an empty host flow downstream as
+/// if it were a real address: the egress profiler recorded destinations with
+/// a blank IP, which then rendered as an unnamed row and warned as policy
+/// drift against a rule it could never match.
 pub(crate) fn parse_addr_parts(addr: &str) -> (Option<String>, Option<String>) {
+    /// `"*"` is the wildcard ss/lsof print for "unbound"; empty is a
+    /// malformed or partially-populated address. Neither is a value.
+    fn part(s: &str) -> Option<String> {
+        if s == "*" || s.is_empty() {
+            None
+        } else {
+            Some(s.to_string())
+        }
+    }
+
     if addr == "*:*" || addr.is_empty() {
         return (None, None);
     }
     if let Some(bracket_end) = addr.rfind("]:") {
-        let ip = addr[1..bracket_end].to_string();
-        let port = addr[bracket_end + 2..].to_string();
-        (Some(ip), Some(port))
+        (part(&addr[1..bracket_end]), part(&addr[bracket_end + 2..]))
     } else if let Some(colon) = addr.rfind(':') {
-        let ip = &addr[..colon];
-        let port = &addr[colon + 1..];
-        let ip = if ip == "*" {
-            None
-        } else {
-            Some(ip.to_string())
-        };
-        let port = if port == "*" {
-            None
-        } else {
-            Some(port.to_string())
-        };
-        (ip, port)
+        (part(&addr[..colon]), part(&addr[colon + 1..]))
     } else {
-        (Some(addr.to_string()), None)
+        (part(addr), None)
     }
 }
 

--- a/src/collectors/connections.rs
+++ b/src/collectors/connections.rs
@@ -360,11 +360,53 @@ impl ConnectionCollector {
                 overlay_proc_snapshot(&mut result, snap);
             }
 
+            // Last, after every attribution source has had its say: replace
+            // the scraped name with the kernel's, which is neither truncated
+            // nor version-stamped. Runs on the final (pid, name) pairs so it
+            // corrects PKTAP and eBPF names too, not just lsof's.
+            canonicalize_process_names(&mut result);
+
             let count = result.len();
             *safe_write(&snapshot, "connections::publish") = Arc::new(result);
             tracing::trace!(target: "netwatch::connections", count, "published connection snapshot");
             busy.store(false, Ordering::SeqCst);
         });
+    }
+}
+
+/// Replace each connection's process name with the identity derived from the
+/// kernel's executable path for its pid.
+///
+/// This is what makes a process's name stable enough to key an egress policy
+/// on. The scraped names are not: `comm` is truncated at 16 bytes (macOS) or
+/// 15 (Linux), so `Google Chrome Helper` and `Google Chrome Helper (GPU)`
+/// collapse together, while lsof reports the executable's filename, which for
+/// version-installed tools is the version itself — Claude Code appeared under
+/// eight different "process names", one per release it had run.
+///
+/// Resolution is per-tick cached by pid: a few hundred connections typically
+/// share a few dozen processes, and a pid cannot be recycled inside one
+/// snapshot. Nothing is cached across ticks, so a recycled pid can never
+/// inherit the previous occupant's name.
+///
+/// A pid the kernel won't answer for keeps whatever name it already had —
+/// this only ever upgrades attribution, never erases it.
+fn canonicalize_process_names(connections: &mut [Connection]) {
+    use std::collections::hash_map::Entry;
+    let mut cache: HashMap<u32, Option<String>> = HashMap::new();
+    for conn in connections {
+        let Some(pid) = conn.pid else {
+            continue;
+        };
+        let resolved = match cache.entry(pid) {
+            Entry::Occupied(e) => e.get().clone(),
+            Entry::Vacant(e) => e
+                .insert(crate::platform::procname::stable_name(pid))
+                .clone(),
+        };
+        if let Some(name) = resolved {
+            conn.process_name = Some(name);
+        }
     }
 }
 
@@ -1192,6 +1234,82 @@ pub fn export_csv(connections: &[Connection], path: &str) -> Result<usize, Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── process identity (issue: version-named + truncated comm) ────────
+
+    /// The kernel's name wins over whatever lsof/PKTAP scraped — that is
+    /// what collapses `Google Chrome He` and the eight `2.1.x` spellings of
+    /// Claude Code onto one stable identity.
+    #[test]
+    fn canonicalize_replaces_the_scraped_name_for_a_live_pid() {
+        let mut conns = vec![make_conn(
+            "TCP",
+            "1.2.3.4:1",
+            "5.6.7.8:443",
+            "ESTABLISHED",
+            1,
+        )];
+        // Our own pid always resolves, so this asserts the overwrite happens.
+        conns[0].pid = Some(std::process::id());
+        conns[0].process_name = Some("2.1.219".into());
+        canonicalize_process_names(&mut conns);
+        let got = conns[0].process_name.as_deref().unwrap();
+        assert_ne!(got, "2.1.219", "scraped name survived");
+        assert!(
+            got.contains("netwatch"),
+            "expected the test binary, got {got:?}"
+        );
+    }
+
+    /// A pid the kernel won't answer for must keep its existing name. This
+    /// only ever upgrades attribution — it must never blank it.
+    #[test]
+    fn canonicalize_keeps_the_existing_name_when_the_pid_is_gone() {
+        let mut conns = vec![make_conn(
+            "TCP",
+            "1.2.3.4:1",
+            "5.6.7.8:443",
+            "ESTABLISHED",
+            1,
+        )];
+        conns[0].pid = Some(u32::MAX);
+        conns[0].process_name = Some("was-here".into());
+        canonicalize_process_names(&mut conns);
+        assert_eq!(conns[0].process_name.as_deref(), Some("was-here"));
+    }
+
+    /// Connections with no pid are left entirely alone.
+    #[test]
+    fn canonicalize_ignores_connections_without_a_pid() {
+        let mut conns = vec![make_conn(
+            "TCP",
+            "1.2.3.4:1",
+            "5.6.7.8:443",
+            "ESTABLISHED",
+            1,
+        )];
+        conns[0].pid = None;
+        conns[0].process_name = Some("keep-me".into());
+        canonicalize_process_names(&mut conns);
+        assert_eq!(conns[0].process_name.as_deref(), Some("keep-me"));
+    }
+
+    /// Two connections from one process resolve to the same name — the
+    /// per-tick cache must not diverge between rows.
+    #[test]
+    fn canonicalize_is_consistent_across_rows_of_one_process() {
+        let me = std::process::id();
+        let mut conns = vec![
+            make_conn("TCP", "1.2.3.4:1", "5.6.7.8:443", "ESTABLISHED", 1),
+            make_conn("TCP", "1.2.3.4:2", "5.6.7.9:443", "ESTABLISHED", 1),
+        ];
+        conns[0].pid = Some(me);
+        conns[1].pid = Some(me);
+        conns[0].process_name = Some("Google Chrome He".into());
+        conns[1].process_name = Some("Google Chrome Helper".into());
+        canonicalize_process_names(&mut conns);
+        assert_eq!(conns[0].process_name, conns[1].process_name);
+    }
 
     fn make_conn(proto: &str, local: &str, remote: &str, state: &str, pid: u32) -> Connection {
         Connection {

--- a/src/collectors/connections.rs
+++ b/src/collectors/connections.rs
@@ -1240,6 +1240,11 @@ mod tests {
     /// The kernel's name wins over whatever lsof/PKTAP scraped — that is
     /// what collapses `Google Chrome He` and the eight `2.1.x` spellings of
     /// Claude Code onto one stable identity.
+    ///
+    /// Unix only: Windows has no executable-path resolver, so `stable_name`
+    /// returns None there by design and names are left as scraped — asserted
+    /// separately in `canonicalize_is_inert_without_a_resolver`.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn canonicalize_replaces_the_scraped_name_for_a_live_pid() {
         let mut conns = vec![make_conn(
@@ -1278,6 +1283,24 @@ mod tests {
         assert_eq!(conns[0].process_name.as_deref(), Some("was-here"));
     }
 
+    /// On a platform with no executable-path resolver, canonicalisation is
+    /// a no-op rather than a name-eraser — the scraped name is all there is.
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[test]
+    fn canonicalize_is_inert_without_a_resolver() {
+        let mut conns = vec![make_conn(
+            "TCP",
+            "1.2.3.4:1",
+            "5.6.7.8:443",
+            "ESTABLISHED",
+            1,
+        )];
+        conns[0].pid = Some(std::process::id());
+        conns[0].process_name = Some("scraped-name".into());
+        canonicalize_process_names(&mut conns);
+        assert_eq!(conns[0].process_name.as_deref(), Some("scraped-name"));
+    }
+
     /// Connections with no pid are left entirely alone.
     #[test]
     fn canonicalize_ignores_connections_without_a_pid() {
@@ -1295,7 +1318,9 @@ mod tests {
     }
 
     /// Two connections from one process resolve to the same name — the
-    /// per-tick cache must not diverge between rows.
+    /// per-tick cache must not diverge between rows. Unix only, for the same
+    /// reason as above.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn canonicalize_is_consistent_across_rows_of_one_process() {
         let me = std::process::id();

--- a/src/collectors/egress.rs
+++ b/src/collectors/egress.rs
@@ -26,6 +26,16 @@ use crate::dpi::AppProtocol;
 /// Cap on distinct processes profiled. A fork-storm of short-lived
 /// process names can't grow the map without bound.
 pub(crate) const MAX_PROCESSES: usize = 256;
+/// Length at which the kernel truncates a process's `comm`. PKTAP carries
+/// `pth_comm[MAXCOMLEN+1]` on macOS and procfs `comm` is `TASK_COMM_LEN-1`
+/// on Linux, while `lsof` reports the untruncated name — so the same program
+/// arrives under two spellings depending on which attribution source won the
+/// tick, and gets two profiles. A name of exactly this length is therefore
+/// *suspected* truncation; see `canonical_process`.
+#[cfg(target_os = "macos")]
+const COMM_TRUNCATE_LEN: usize = 16;
+#[cfg(not(target_os = "macos"))]
+const COMM_TRUNCATE_LEN: usize = 15;
 /// Cap on distinct destinations tracked per process.
 const MAX_DESTS_PER_PROCESS: usize = 128;
 /// Re-warn at most this often for the same (process, destination, port)
@@ -72,6 +82,14 @@ pub struct EgressDest {
 /// Identity of a destination within a process profile: the most specific
 /// name available (SNI → ASN org → raw IP) paired with the port. Mirrors the
 /// roadmap's rule granularity — prefer SNI, fall back to ASN, avoid raw IP.
+/// `(label, port)`, where `label` is `sni.or(asn_org).unwrap_or(ip)` at the
+/// moment the destination was first seen.
+///
+/// The label is not a redundant copy of the fields below it — when a
+/// destination has neither an SNI nor an ASN, it is the *only* surviving
+/// record of the address it was learned from, and both `load_profiles` and
+/// the Egress table fall back to it to repair rows whose `last_ip` is blank.
+/// Don't "simplify" it away.
 type DestKey = (String, u16);
 
 /// Per-process egress profile: the set of distinct destinations observed.
@@ -213,7 +231,11 @@ impl EgressProfiler {
             let (Some(ip), Some(port_str)) = crate::app::parse_addr_parts(&conn.remote_addr) else {
                 continue;
             };
-            if is_private_ip(&ip) {
+            // Belt and braces with `parse_addr_parts`, which no longer yields
+            // an empty host — but `is_private_ip("")` is false, so an empty IP
+            // would otherwise clear every guard here and be recorded as a real
+            // destination with no name and no address.
+            if ip.is_empty() || is_private_ip(&ip) {
                 continue;
             }
             let Ok(port) = port_str.parse::<u16>() else {
@@ -248,10 +270,20 @@ impl EgressProfiler {
         ech: bool,
         now: Instant,
     ) {
+        // A policy may be authored against either spelling of a truncated
+        // name — the user promoted whichever one the baseline held. Try the
+        // observed name first, then its canonical form, so a flow attributed
+        // under the truncated `comm` still matches a rule declared under the
+        // full name (and vice versa). Computed before borrowing the policy.
+        let canonical = self.canonical_process(process);
         let Some(policy) = &self.policy else {
             return;
         };
-        let Some(rule) = policy.process.get(process) else {
+        let Some(rule) = policy
+            .process
+            .get(process)
+            .or_else(|| policy.process.get(canonical.as_str()))
+        else {
             return;
         };
         let Some(mut reason) = rule.violation(sni.as_deref(), asn_org.as_deref(), ip, port) else {
@@ -320,7 +352,14 @@ impl EgressProfiler {
     /// no policy is loaded or the process has no rule (nothing to check),
     /// `Some(true)` when allowed, `Some(false)` when it drifts.
     pub fn dest_allowed(&self, process: &str, dest: &EgressDest) -> Option<bool> {
-        let rule = self.policy.as_ref()?.process.get(process)?;
+        let policy = self.policy.as_ref()?;
+        // Same both-spellings lookup as `check_policy`, so the table verdict
+        // and the warnings panel can never disagree about a truncated name.
+        let canonical = self.canonical_process(process);
+        let rule = policy
+            .process
+            .get(process)
+            .or_else(|| policy.process.get(canonical.as_str()))?;
         Some(
             rule.violation(
                 dest.sni.as_deref(),
@@ -399,6 +438,111 @@ impl EgressProfiler {
         self.upsert(process, (label, port), sni, asn_org, port, ip, ech, now);
     }
 
+    /// Resolve the profile key for an observed process name, folding a
+    /// kernel-truncated `comm` into the full name when we've already seen it.
+    ///
+    /// Only a name of exactly `COMM_TRUNCATE_LEN` bytes is a truncation
+    /// candidate — that's the one length the kernel could have cut. A shorter
+    /// name is complete and must never be merged, which is what keeps VS
+    /// Code's `Code Helper` (11 bytes, a real distinct process) separate from
+    /// `Code Helper (Plu` (16 bytes, truncated `Code Helper (Plugin)`).
+    ///
+    /// When several known names share the prefix the truncation is genuinely
+    /// ambiguous (`Google Chrome Helper` vs `Google Chrome Helper (GPU)` both
+    /// truncate to `Google Chrome He`). Pick the shortest match so the choice
+    /// is deterministic across runs rather than HashMap-order dependent.
+    fn canonical_process(&self, process: &str) -> String {
+        if process.len() != COMM_TRUNCATE_LEN {
+            return process.to_string();
+        }
+        self.profiles
+            .keys()
+            .filter(|k| k.len() > process.len() && k.starts_with(process))
+            .min_by(|a, b| {
+                a.len()
+                    .cmp(&b.len())
+                    .then_with(|| a.as_str().cmp(b.as_str()))
+            })
+            .cloned()
+            .unwrap_or_else(|| process.to_string())
+    }
+
+    /// Fold an existing truncated profile into `full` when the untruncated
+    /// name shows up later. Called when a longer name arrives and a profile
+    /// keyed by its truncated form already exists — without this the merge
+    /// only works in one direction and the split survives whichever order the
+    /// two spellings happened to appear in.
+    fn absorb_truncated(&mut self, full: &str) {
+        if full.len() <= COMM_TRUNCATE_LEN {
+            return;
+        }
+        let truncated = match full.get(..COMM_TRUNCATE_LEN) {
+            Some(t) => t.to_string(),
+            // Not a char boundary — a multi-byte name the kernel would have
+            // cut mid-character. Leave it alone rather than guess.
+            None => return,
+        };
+        // Only fold when `full` is the name the truncation most plausibly
+        // belongs to. Ambiguity is resolved the same way as
+        // `canonical_process`: shortest candidate wins, ties broken
+        // alphabetically, so the choice is stable across runs. `full` is a
+        // candidate whether or not it already has a profile — it usually
+        // doesn't yet, since this runs on the way to creating it.
+        let shortest_claimant = self
+            .profiles
+            .keys()
+            .map(String::as_str)
+            .filter(|k| k.len() > COMM_TRUNCATE_LEN && k.starts_with(&truncated))
+            .chain(std::iter::once(full))
+            .min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
+        if shortest_claimant != Some(full) {
+            return;
+        }
+        let Some(old) = self.profiles.remove(&truncated) else {
+            return;
+        };
+        let target = self
+            .profiles
+            .entry(full.to_string())
+            .or_insert_with(|| EgressProfile {
+                process: full.to_string(),
+                dests: HashMap::new(),
+                last_seen: old.last_seen,
+            });
+        target.last_seen = target.last_seen.max(old.last_seen);
+        for (key, dest) in old.dests {
+            match target.dests.get_mut(&key) {
+                // Same destination under both spellings: keep one row with
+                // the summed hit count and the widest time span.
+                Some(existing) => {
+                    existing.count += dest.count;
+                    existing.first_seen = existing.first_seen.min(dest.first_seen);
+                    existing.last_seen = existing.last_seen.max(dest.last_seen);
+                    existing.ech |= dest.ech;
+                    if existing.sni.is_none() {
+                        existing.sni = dest.sni;
+                    }
+                    if existing.asn_org.is_none() {
+                        existing.asn_org = dest.asn_org;
+                    }
+                    if existing.last_ip.is_empty() {
+                        existing.last_ip = dest.last_ip;
+                    }
+                }
+                None => {
+                    if target.dests.len() < MAX_DESTS_PER_PROCESS {
+                        target.dests.insert(key, dest);
+                    }
+                }
+            }
+        }
+        // Violation tallies follow the profile, or the counter resets to zero
+        // the moment the two spellings merge.
+        if let Some(n) = self.violation_totals.remove(&truncated) {
+            *self.violation_totals.entry(full.to_string()).or_insert(0) += n;
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn upsert(
         &mut self,
@@ -411,6 +555,12 @@ impl EgressProfiler {
         ech: bool,
         now: SystemTime,
     ) {
+        // Fold kernel-truncated and untruncated spellings of the same program
+        // onto one key, in whichever order they arrive.
+        self.absorb_truncated(process);
+        let process = self.canonical_process(process);
+        let process = process.as_str();
+
         let profile = self
             .profiles
             .entry(process.to_string())
@@ -425,7 +575,12 @@ impl EgressProfiler {
             dest.last_seen = now;
             dest.count += 1;
             dest.ech |= ech;
-            dest.last_ip = ip.to_string();
+            // Only ever upgrade the endpoint. A flow whose address we couldn't
+            // read must not downgrade a destination we already know the IP for
+            // — that turned named rows into blank ones on disk.
+            if !ip.is_empty() {
+                dest.last_ip = ip.to_string();
+            }
             // Backfill a name/ASN that wasn't resolved on first sight (SNI
             // appears once the ClientHello is parsed; ASN once geo resolves).
             if dest.sni.is_none() {
@@ -650,6 +805,7 @@ impl EgressProfiler {
             }
         };
         let now = SystemTime::now();
+        let mut dropped: HashMap<String, usize> = HashMap::new();
         for profile in persisted.profiles {
             for dest in profile.dests {
                 let last_seen = from_unix_secs(dest.last_seen);
@@ -670,8 +826,26 @@ impl EgressProfiler {
                     });
                 entry.last_seen = entry.last_seen.max(last_seen);
                 if entry.dests.len() >= MAX_DESTS_PER_PROCESS {
+                    // Silently dropping these is what makes a capped profile
+                    // look like drift later: the destination is gone from the
+                    // baseline but the traffic keeps happening. Count them and
+                    // say so once per load rather than per row.
+                    *dropped.entry(profile.process.clone()).or_insert(0usize) += 1;
                     continue;
                 }
+                // Repair a blank IP from the key label. `label` is
+                // `sni.or(asn_org).unwrap_or(ip)`, so when neither name is
+                // present the label *is* the address it was learned from.
+                // This recovers two cases without a migration: baselines
+                // written before the `ip` field existed (it defaults to ""),
+                // and rows an unreadable address blanked. Guarded on both
+                // names being absent so a hostname never lands in the IP.
+                let last_ip = if dest.ip.is_empty() && dest.sni.is_none() && dest.asn_org.is_none()
+                {
+                    dest.label.clone()
+                } else {
+                    dest.ip
+                };
                 entry
                     .dests
                     .entry((dest.label, dest.port))
@@ -679,13 +853,42 @@ impl EgressProfiler {
                         sni: dest.sni,
                         asn_org: dest.asn_org,
                         port: dest.port,
-                        last_ip: dest.ip,
+                        last_ip,
                         ech: dest.ech,
                         first_seen: from_unix_secs(dest.first_seen),
                         last_seen,
                         count: dest.count,
                     });
             }
+        }
+        // A baseline saved before truncated names were folded holds both
+        // spellings. Merge them once, on load, rather than waiting for new
+        // traffic to arrive under the full name.
+        let full_names: Vec<String> = self
+            .profiles
+            .keys()
+            .filter(|k| k.len() > COMM_TRUNCATE_LEN)
+            .cloned()
+            .collect();
+        for full in full_names {
+            self.absorb_truncated(&full);
+        }
+        if !dropped.is_empty() {
+            let total: usize = dropped.values().sum();
+            let mut worst: Vec<_> = dropped.into_iter().collect();
+            worst.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+            worst.truncate(3);
+            let detail = worst
+                .iter()
+                .map(|(p, n)| format!("{p} (+{n})"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            tracing::warn!(
+                target: "netwatch::egress",
+                dropped = total,
+                cap = MAX_DESTS_PER_PROCESS,
+                "egress baseline truncated at the per-process destination cap: {detail}"
+            );
         }
         self.evict_processes_if_needed();
     }
@@ -829,7 +1032,18 @@ impl ProcessRule {
                 asn_org.is_some_and(|a| self.allow_asn.iter().any(|x| x.eq_ignore_ascii_case(a)));
             let ip_ok = self.allow_ip.iter().any(|x| x == ip);
             if !sni_ok && !asn_ok && !ip_ok {
-                let dest = sni.or(asn_org).unwrap_or(ip);
+                // Never build a message with an empty subject: a destination
+                // with no SNI, no ASN and no readable IP used to warn as
+                // " not in allowlist", which reads as a bug rather than a
+                // finding. Name the gap instead.
+                let dest = sni
+                    .or(asn_org)
+                    .filter(|d| !d.is_empty())
+                    .unwrap_or(if ip.is_empty() {
+                        "unknown destination"
+                    } else {
+                        ip
+                    });
                 return Some(format!("{dest} not in allowlist"));
             }
         }
@@ -2083,5 +2297,243 @@ mod tests {
             "+1 SNI, +0 ASN, +0 IP, +0 ports"
         );
         assert_eq!(rule_diff(Some(&new), &new), "no additions");
+    }
+}
+
+/// Regressions for the blank-destination / split-profile defects found in the
+/// 2026-07-26 review. Each test names the failure it locks out.
+#[cfg(test)]
+mod blank_and_split_regressions {
+    use super::*;
+
+    fn sni(host: &str) -> Option<String> {
+        Some(host.to_string())
+    }
+
+    fn dest(sni: Option<&str>, asn: Option<&str>, ip: &str) -> EgressDest {
+        EgressDest {
+            sni: sni.map(str::to_string),
+            asn_org: asn.map(str::to_string),
+            port: 443,
+            last_ip: ip.to_string(),
+            ech: false,
+            first_seen: SystemTime::now(),
+            last_seen: SystemTime::now(),
+            count: 1,
+        }
+    }
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("nw-egress-{tag}-{}", std::process::id()));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    // ── blank destinations (Finding 2) ──────────────────────────────────
+
+    /// An address with an empty host is not an address. Returning `Some("")`
+    /// here is what let blank destinations into the baseline at all.
+    #[test]
+    fn empty_host_parses_as_no_host() {
+        assert_eq!(crate::app::parse_addr_parts(":443").0, None);
+        assert_eq!(
+            crate::app::parse_addr_parts(":443").1.as_deref(),
+            Some("443")
+        );
+        // The wildcard and well-formed cases are unchanged.
+        assert_eq!(crate::app::parse_addr_parts("*:443").0, None);
+        assert_eq!(
+            crate::app::parse_addr_parts("1.2.3.4:443").0.as_deref(),
+            Some("1.2.3.4")
+        );
+        assert_eq!(
+            crate::app::parse_addr_parts("[2001:db8::1]:443")
+                .0
+                .as_deref(),
+            Some("2001:db8::1")
+        );
+    }
+
+    /// `is_private_ip("")` is false, so an empty IP clears every guard in
+    /// `observe` unless it is rejected explicitly.
+    #[test]
+    fn empty_ip_is_not_mistaken_for_public() {
+        assert!(!is_private_ip(""), "empty IP is not private…");
+        // …which is exactly why observe() needs its own emptiness check.
+        let mut p = EgressProfiler::new();
+        p.record("curl", "", 443, None, None, SystemTime::now());
+        // record() bypasses observe()'s guard, so this asserts the *storage*
+        // shape the guard is protecting: nothing else should ever see it.
+        assert_eq!(p.dest_count(), 1);
+    }
+
+    /// A flow whose address couldn't be read must not erase an endpoint we
+    /// already resolved — this is what blanked named rows on disk.
+    #[test]
+    fn unreadable_address_does_not_erase_a_known_ip() {
+        let mut p = EgressProfiler::new();
+        let t = SystemTime::now();
+        p.record("curl", "203.0.113.7", 443, sni("api.example.com"), None, t);
+        p.record("curl", "", 443, sni("api.example.com"), None, t);
+        let snap = p.snapshot();
+        let d = snap[0].dests.values().next().unwrap();
+        assert_eq!(d.last_ip, "203.0.113.7", "known IP was downgraded");
+        assert_eq!(d.count, 2, "both flows counted");
+    }
+
+    /// A destination with nothing readable must not warn with an empty
+    /// subject — " not in allowlist" reads as a bug, not a finding.
+    #[test]
+    fn violation_never_names_an_empty_destination() {
+        let rule = ProcessRule {
+            allow_sni: vec!["api.example.com".into()],
+            allow_asn: vec![],
+            allow_ip: vec![],
+            allow_ports: vec![],
+        };
+        let msg = rule.violation(None, None, "", 443).unwrap();
+        assert_eq!(msg, "unknown destination not in allowlist");
+        assert!(!msg.starts_with(' '), "no empty subject");
+    }
+
+    // ── baseline repair (Findings 2c + 3) ───────────────────────────────
+
+    /// A baseline written before the `ip` field existed has the address only
+    /// in the key label. Loading must recover it rather than surfacing a
+    /// blank row that warns as drift.
+    #[test]
+    fn legacy_baseline_recovers_the_ip_from_the_label() {
+        let dir = tmpdir("legacy");
+        let path = dir.join("legacy.json");
+        let now = unix_secs(SystemTime::now());
+        let legacy = format!(
+            r#"{{"version":1,"profiles":[{{"process":"curl","dests":[
+               {{"label":"203.0.113.7","port":443,"sni":null,"asn_org":null,
+                 "first_seen":{now},"last_seen":{now},"count":5}}]}}]}}"#
+        );
+        std::fs::write(&path, legacy).unwrap();
+
+        let mut p = EgressProfiler::new();
+        p.load_profiles(&path);
+        let snap = p.snapshot();
+        let d = snap[0].dests.values().next().unwrap();
+        assert_eq!(d.last_ip, "203.0.113.7", "IP recovered from label");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The label repair must never put a *hostname* in the IP column — it
+    /// only applies when neither name was recorded.
+    #[test]
+    fn label_repair_does_not_put_a_hostname_in_the_ip_field() {
+        let dir = tmpdir("named");
+        let path = dir.join("named.json");
+        let now = unix_secs(SystemTime::now());
+        let body = format!(
+            r#"{{"version":1,"profiles":[{{"process":"curl","dests":[
+               {{"label":"api.example.com","port":443,"sni":"api.example.com",
+                 "asn_org":null,"ip":"","first_seen":{now},"last_seen":{now},"count":1}}]}}]}}"#
+        );
+        std::fs::write(&path, body).unwrap();
+
+        let mut p = EgressProfiler::new();
+        p.load_profiles(&path);
+        let snap = p.snapshot();
+        let d = snap[0].dests.values().next().unwrap();
+        assert_eq!(d.last_ip, "", "hostname must not masquerade as an IP");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── truncated process names (Finding 1a) ────────────────────────────
+
+    /// The core split: PKTAP's 16-byte `comm` and lsof's full name are the
+    /// same program and must share one profile, in either arrival order.
+    #[test]
+    fn truncated_and_full_names_merge_in_both_directions() {
+        let full = "Google Chrome Helper";
+        let trunc = &full[..COMM_TRUNCATE_LEN];
+        let t = SystemTime::now();
+
+        // truncated first, then full
+        let mut a = EgressProfiler::new();
+        a.record(trunc, "203.0.113.1", 443, sni("a.example.com"), None, t);
+        a.record(full, "203.0.113.2", 443, sni("b.example.com"), None, t);
+        assert_eq!(a.process_count(), 1, "did not merge (truncated first)");
+        assert_eq!(a.snapshot()[0].process, full);
+        assert_eq!(a.dest_count(), 2, "both destinations kept");
+
+        // full first, then truncated
+        let mut b = EgressProfiler::new();
+        b.record(full, "203.0.113.2", 443, sni("b.example.com"), None, t);
+        b.record(trunc, "203.0.113.1", 443, sni("a.example.com"), None, t);
+        assert_eq!(b.process_count(), 1, "did not merge (full first)");
+        assert_eq!(b.snapshot()[0].process, full);
+    }
+
+    /// The guard that keeps the merge honest: a name shorter than the
+    /// truncation length is complete, so VS Code's real `Code Helper` must
+    /// stay separate from the truncated `Code Helper (Plugin)`.
+    #[test]
+    fn a_complete_short_name_is_never_merged() {
+        let t = SystemTime::now();
+        let mut p = EgressProfiler::new();
+        p.record("Code Helper", "203.0.113.1", 443, None, None, t);
+        p.record("Code Helper (Plugin)", "203.0.113.2", 443, None, None, t);
+        assert_eq!(
+            p.process_count(),
+            2,
+            "'Code Helper' is 11 bytes — complete, not truncated"
+        );
+    }
+
+    /// Merging must carry the hit counts, not silently reset them.
+    #[test]
+    fn merge_sums_counts_for_a_shared_destination() {
+        let full = "Google Chrome Helper";
+        let trunc = &full[..COMM_TRUNCATE_LEN];
+        let t = SystemTime::now();
+        let mut p = EgressProfiler::new();
+        p.record(trunc, "203.0.113.1", 443, sni("a.example.com"), None, t);
+        p.record(trunc, "203.0.113.1", 443, sni("a.example.com"), None, t);
+        p.record(full, "203.0.113.1", 443, sni("a.example.com"), None, t);
+        assert_eq!(p.process_count(), 1);
+        let snap = p.snapshot();
+        assert_eq!(snap[0].dests.values().next().unwrap().count, 3);
+    }
+
+    /// A policy promoted under the full name must cover a flow attributed
+    /// under the truncated one — otherwise promote doesn't cover its own
+    /// baseline, which is the whole promise of warn-on-drift.
+    #[test]
+    fn policy_under_the_full_name_covers_the_truncated_spelling() {
+        let full = "Google Chrome Helper";
+        let trunc = &full[..COMM_TRUNCATE_LEN];
+        let mut p = EgressProfiler::new();
+        let mut policy = EgressPolicy::default();
+        policy.process.insert(
+            full.into(),
+            ProcessRule {
+                allow_sni: vec!["a.example.com".into()],
+                allow_asn: vec![],
+                allow_ip: vec![],
+                allow_ports: vec![],
+            },
+        );
+        p.set_policy(Some(policy));
+        // Seed the full-name profile so the truncated form resolves to it.
+        p.record(
+            full,
+            "203.0.113.1",
+            443,
+            sni("a.example.com"),
+            None,
+            SystemTime::now(),
+        );
+
+        let allowed = dest(Some("a.example.com"), None, "203.0.113.1");
+        assert_eq!(
+            p.dest_allowed(trunc, &allowed),
+            Some(true),
+            "declared destination warned as drift under the truncated name"
+        );
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -56,6 +56,11 @@ pub struct GraphOpts {
     /// interpolating column colors and as the fallback when no Rgb
     /// information is available.
     pub bg: Color,
+    /// True under the `terminal` theme, where every color must resolve
+    /// through the user's own palette. Fade and the grid interpolate in
+    /// RGB, so they switch off rather than emit 24-bit values the theme
+    /// exists to avoid.
+    pub terminal_palette: bool,
 }
 
 impl Default for GraphOpts {
@@ -63,6 +68,7 @@ impl Default for GraphOpts {
         Self {
             fade: false,
             bg: Color::Reset,
+            terminal_palette: false,
         }
     }
 }
@@ -121,7 +127,7 @@ pub fn render_with_max(
         return;
     }
     if opts.fade && area.width >= GRID_MIN_W && area.height >= GRID_MIN_H {
-        render_grid(f.buffer_mut(), area, opts.bg);
+        render_grid(f.buffer_mut(), area, opts.bg, opts.terminal_palette);
     }
     match style {
         GraphStyle::Bars => render_bars(f.buffer_mut(), area, data, max, base, opts),
@@ -155,7 +161,7 @@ fn render_bars(buf: &mut Buffer, area: Rect, data: &[u64], max: u64, base: Color
 
         let color = if opts.fade {
             let alpha = MIN_FADE_ALPHA + (1.0 - MIN_FADE_ALPHA) * (i as f32 / n_minus_1);
-            fade_color(base, opts.bg, alpha)
+            fade_color(base, opts.bg, alpha, opts.terminal_palette)
         } else {
             base
         };
@@ -236,7 +242,7 @@ fn render_dots(
             }
             let cell_color = if opts.fade {
                 let alpha = MIN_FADE_ALPHA + (1.0 - MIN_FADE_ALPHA) * (x as f32 / n_minus_1);
-                fade_color(color, opts.bg, alpha)
+                fade_color(color, opts.bg, alpha, opts.terminal_palette)
             } else {
                 color
             };
@@ -254,7 +260,14 @@ fn render_dots(
 /// works in RGB; named/indexed colors are returned unchanged so we don't
 /// silently lose them. Themes ship with `Color::Rgb` everywhere, so this
 /// is the common path.
-pub fn fade_color(base: Color, bg: Color, alpha: f32) -> Color {
+pub fn fade_color(base: Color, bg: Color, alpha: f32, defer_to_terminal: bool) -> Color {
+    // No 16-color equivalent of a gradient exists, so fade degrades to off
+    // rather than to wrong. Interpolating would also be doubly wrong here:
+    // `bg` is Reset under that theme, so it would fade toward an assumed
+    // black regardless of the terminal's real background.
+    if defer_to_terminal {
+        return base;
+    }
     let alpha = alpha.clamp(0.0, 1.0);
     let (br, bgc, bb) = match to_rgb_or_default(base, (255, 255, 255)) {
         rgb => rgb,
@@ -322,12 +335,17 @@ pub fn row_fade_alpha(row_idx: usize, total_visible_rows: usize) -> f32 {
 /// touching every per-cell color computation upstream. Spans without an
 /// explicit fg are left untouched so unstyled text doesn't suddenly
 /// pick up a fade color it wasn't supposed to have.
-pub fn fade_spans_fg(spans: Vec<Span<'_>>, bg: Color, alpha: f32) -> Vec<Span<'_>> {
+pub fn fade_spans_fg(
+    spans: Vec<Span<'_>>,
+    bg: Color,
+    alpha: f32,
+    defer_to_terminal: bool,
+) -> Vec<Span<'_>> {
     spans
         .into_iter()
         .map(|mut s| {
             if let Some(fg) = s.style.fg {
-                s.style = s.style.fg(fade_color(fg, bg, alpha));
+                s.style = s.style.fg(fade_color(fg, bg, alpha, defer_to_terminal));
             }
             s
         })
@@ -338,10 +356,17 @@ pub fn fade_spans_fg(spans: Vec<Span<'_>>, bg: Color, alpha: f32) -> Vec<Span<'_
 /// cell overwrites a grid cell; the empty regions of the chart show the
 /// grid through. Only runs on charts at least `GRID_MIN_W` × `GRID_MIN_H`
 /// to avoid making narrow sparklines look noisy.
-fn render_grid(buf: &mut Buffer, area: Rect, bg: Color) {
+fn render_grid(buf: &mut Buffer, area: Rect, bg: Color, defer_to_terminal: bool) {
     // Grid color: half-way between bg and a neutral gray, so it sits well
     // below the data on every theme.
-    let grid_color = fade_color(Color::Rgb(150, 150, 150), bg, 0.20);
+    // The grid's base is a fixed grey, so it would survive fade_color's
+    // passthrough as raw RGB. DarkGray is the palette's own answer to
+    // "faint chrome" and tracks whatever the user's theme defines.
+    let grid_color = if defer_to_terminal {
+        Color::DarkGray
+    } else {
+        fade_color(Color::Rgb(150, 150, 150), bg, 0.20, false)
+    };
     let cell_w = area.width as usize;
     let cell_h = area.height as usize;
     if cell_w < GRID_MIN_W as usize || cell_h < GRID_MIN_H as usize {
@@ -395,13 +420,34 @@ mod tests {
     }
 
     #[test]
+    fn fade_passes_base_through_untouched_for_terminal_theme() {
+        // Fade interpolates in RGB. Under the `terminal` theme that would
+        // emit 24-bit color for every faded cell and silently undo the one
+        // guarantee the theme makes. Measured at 623 escapes per frame in
+        // syswatch, which shares this fade design, before it was fixed.
+        let base = Color::Cyan;
+        for alpha in [0.0, 0.3, 0.55, 1.0] {
+            assert_eq!(
+                fade_color(base, Color::Reset, alpha, true),
+                base,
+                "alpha {alpha} must pass through under the terminal theme"
+            );
+        }
+        // Every other theme keeps its gradient.
+        assert!(matches!(
+            fade_color(Color::Rgb(200, 100, 50), Color::Rgb(0, 0, 0), 0.5, false),
+            Color::Rgb(..)
+        ));
+    }
+
+    #[test]
     fn fade_color_endpoints_match_inputs() {
         let base = Color::Rgb(200, 100, 50);
         let bg = Color::Rgb(0, 0, 0);
         // alpha = 1.0 → fully base
-        assert_eq!(fade_color(base, bg, 1.0), base);
+        assert_eq!(fade_color(base, bg, 1.0, false), base);
         // alpha = 0.0 → fully bg
-        assert_eq!(fade_color(base, bg, 0.0), bg);
+        assert_eq!(fade_color(base, bg, 0.0, false), bg);
     }
 
     #[test]
@@ -409,7 +455,7 @@ mod tests {
         let base = Color::Rgb(200, 100, 50);
         let bg = Color::Rgb(0, 0, 0);
         // alpha = 0.5 → midpoint
-        let mid = fade_color(base, bg, 0.5);
+        let mid = fade_color(base, bg, 0.5, false);
         assert_eq!(mid, Color::Rgb(100, 50, 25));
     }
 
@@ -417,8 +463,8 @@ mod tests {
     fn fade_color_clamps_out_of_range_alpha() {
         let base = Color::Rgb(200, 100, 50);
         let bg = Color::Rgb(0, 0, 0);
-        assert_eq!(fade_color(base, bg, 2.0), base);
-        assert_eq!(fade_color(base, bg, -1.0), bg);
+        assert_eq!(fade_color(base, bg, 2.0, false), base);
+        assert_eq!(fade_color(base, bg, -1.0, false), bg);
     }
 
     #[test]
@@ -426,7 +472,7 @@ mod tests {
         let base = Color::Green;
         let bg = Color::Reset;
         // Both unresolvable → result still RGB (fallback white → fallback black)
-        let faded = fade_color(base, bg, 0.5);
+        let faded = fade_color(base, bg, 0.5, false);
         assert!(matches!(faded, Color::Rgb(_, _, _)));
     }
 
@@ -441,9 +487,9 @@ mod tests {
         let base = Color::Green;
         let bg = Color::Reset;
         // Full intensity → standard ANSI green.
-        assert_eq!(fade_color(base, bg, 1.0), Color::Rgb(0, 170, 0));
+        assert_eq!(fade_color(base, bg, 1.0, false), Color::Rgb(0, 170, 0));
         // Dim end → still green, just darker.
-        let dim = fade_color(base, bg, 0.3);
+        let dim = fade_color(base, bg, 0.3, false);
         match dim {
             Color::Rgb(r, g, b) => {
                 assert_eq!(r, 0, "red channel should stay zero");

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -4,6 +4,9 @@ pub mod linux;
 pub mod macos;
 #[cfg(target_os = "macos")]
 pub mod pktap;
+/// Kernel-derived process identity — every platform, including the fallback
+/// that returns nothing so callers keep the name they already had.
+pub mod procname;
 #[cfg(target_os = "windows")]
 pub mod windows;
 

--- a/src/platform/procname.rs
+++ b/src/platform/procname.rs
@@ -1,0 +1,264 @@
+//! Stable process identity, derived from the kernel's view of the executable.
+//!
+//! The name a connection is attributed to has three sources, none of which is
+//! usable on its own:
+//!
+//! - **`comm`** (PKTAP's `pth_comm`, procfs `comm`) is kernel-derived and
+//!   therefore trustworthy, but the kernel truncates it — 16 bytes on macOS,
+//!   15 on Linux. `Google Chrome Helper` and `Google Chrome Helper (GPU)`
+//!   both arrive as `Google Chrome He`.
+//! - **`lsof`'s command** is untruncated, but it is just the executable's
+//!   name, which is not always meaningful: Claude Code installs to
+//!   `~/.local/share/claude/versions/2.1.219`, so every process shows up
+//!   under its *version number*, and every upgrade invents a new identity.
+//! - **`argv[0]`** carries the name a human would recognise (`claude`), and is
+//!   the obvious fix — but any process can set it to anything. Keying an
+//!   egress *policy* on it would let a program claim another's allowlist by
+//!   renaming itself. We never read it.
+//!
+//! So identity comes from the executable path, which the kernel owns and a
+//! process cannot forge, with one transformation: when the file itself is
+//! named like a bare version, the name is taken from the nearest meaningful
+//! parent directory instead. That collapses
+//! `.../claude/versions/2.1.219` → `claude` while leaving `python3.12`,
+//! `7z` and `Google Chrome Helper (GPU)` exactly as they are.
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use std::path::{Path, PathBuf};
+
+/// Directory names that describe *where* a binary lives rather than *what*
+/// it is. Skipped when walking up from a version-named executable.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+const GENERIC_DIRS: &[&str] = &[
+    "versions",
+    "version",
+    "releases",
+    "release",
+    "current",
+    "bin",
+    "sbin",
+    "libexec",
+    "MacOS",
+    "Contents",
+    "Resources",
+    "dist",
+    "build",
+    "target",
+    "node_modules",
+    ".bin",
+];
+
+/// True for a component that looks like a bare version string — `2.1.219`,
+/// `v1.2.3`, `0.26`, `1.0.0-rc1`.
+///
+/// Deliberately strict: a component containing any letter other than a
+/// leading `v` is a name, not a version. That is what keeps `python3.12`,
+/// `7z` and `libexec2` from being collapsed into their parent directory.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn looks_like_version(s: &str) -> bool {
+    let body = s.strip_prefix('v').unwrap_or(s);
+    if body.is_empty() {
+        return false;
+    }
+    // Must start with a digit and contain at least one separator or be all
+    // digits — `2`, `2.1`, `2.1.219`, `1.0.0-rc1`.
+    if !body.starts_with(|c: char| c.is_ascii_digit()) {
+        return false;
+    }
+    let mut has_digit = false;
+    for c in body.chars() {
+        if c.is_ascii_digit() {
+            has_digit = true;
+        } else if c != '.' && c != '-' && c != '_' {
+            // Allow a trailing alphanumeric qualifier only after a separator
+            // (`1.0.0-rc1`), which the split below handles; anything else
+            // means this is a name.
+            if !body.contains('-') && !body.contains('.') {
+                return false;
+            }
+            // A letter is only acceptable inside a post-separator qualifier.
+            let tail = body.rsplit(['-', '.']).next().unwrap_or("");
+            if !tail.chars().any(|t| t.is_ascii_digit()) {
+                return false;
+            }
+        }
+    }
+    has_digit
+}
+
+/// Derive the identity from an executable path.
+///
+/// Exposed for testing — the path is normally supplied by the kernel.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+pub fn name_from_path(path: &Path) -> Option<String> {
+    let base = path.file_name()?.to_string_lossy().into_owned();
+    if !looks_like_version(&base) {
+        return Some(base);
+    }
+    // The file is a version. Walk up for the first component that names
+    // something, skipping layout directories and further version segments.
+    for ancestor in path.ancestors().skip(1) {
+        let Some(component) = ancestor.file_name() else {
+            break;
+        };
+        let c = component.to_string_lossy();
+        if c.is_empty() || looks_like_version(&c) {
+            continue;
+        }
+        if GENERIC_DIRS
+            .iter()
+            .any(|g| g.eq_ignore_ascii_case(c.as_ref()))
+        {
+            continue;
+        }
+        return Some(c.into_owned());
+    }
+    // Nothing better upstream — the version string is all we have.
+    Some(base)
+}
+
+/// The kernel's path for a running process's executable.
+///
+/// `None` when the process is gone, is a kernel task with no image, or the
+/// caller lacks the privilege to ask.
+#[cfg(target_os = "macos")]
+pub fn executable_path(pid: u32) -> Option<PathBuf> {
+    use std::os::raw::{c_int, c_void};
+
+    // `proc_pidpath` lives in libproc, which is part of libSystem and so is
+    // already linked — no extra dependency.
+    extern "C" {
+        fn proc_pidpath(pid: c_int, buffer: *mut c_void, buffersize: u32) -> c_int;
+    }
+
+    // PROC_PIDPATHINFO_MAXSIZE (sys/proc_info.h).
+    const MAX: usize = 4 * 1024;
+    let mut buf = vec![0u8; MAX];
+    // SAFETY: `buf` is a live allocation of exactly `MAX` bytes and the
+    // length we hand across matches it; the call only writes within that
+    // range and returns the byte count written.
+    let n = unsafe { proc_pidpath(pid as c_int, buf.as_mut_ptr() as *mut c_void, MAX as u32) };
+    if n <= 0 {
+        return None;
+    }
+    buf.truncate(n as usize);
+    Some(PathBuf::from(String::from_utf8_lossy(&buf).into_owned()))
+}
+
+#[cfg(target_os = "linux")]
+pub fn executable_path(pid: u32) -> Option<PathBuf> {
+    // `/proc/<pid>/exe` is a kernel-maintained symlink; reading it requires
+    // ptrace-level access to the target, so this returns None for other
+    // users' processes when unprivileged. `comm` remains the fallback.
+    std::fs::read_link(format!("/proc/{pid}/exe")).ok()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn executable_path(_pid: u32) -> Option<std::path::PathBuf> {
+    None
+}
+
+/// Stable identity for a pid, or `None` when the kernel won't tell us and the
+/// caller should keep whatever name it already had.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+pub fn stable_name(pid: u32) -> Option<String> {
+    name_from_path(&executable_path(pid)?)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn stable_name(_pid: u32) -> Option<String> {
+    None
+}
+
+#[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
+mod tests {
+    use super::*;
+
+    fn n(p: &str) -> Option<String> {
+        name_from_path(Path::new(p))
+    }
+
+    #[test]
+    fn ordinary_executables_keep_their_own_name() {
+        assert_eq!(n("/usr/bin/curl").as_deref(), Some("curl"));
+        assert_eq!(n("/usr/bin/python3.12").as_deref(), Some("python3.12"));
+        assert_eq!(n("/opt/homebrew/bin/7z").as_deref(), Some("7z"));
+    }
+
+    /// The untruncated name is the whole point — this is what `comm` cuts to
+    /// `Google Chrome He` and what split the profile in two.
+    #[test]
+    fn long_names_survive_intact() {
+        assert_eq!(
+            n("/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/1/Helpers/Google Chrome Helper (GPU).app/Contents/MacOS/Google Chrome Helper (GPU)")
+                .as_deref(),
+            Some("Google Chrome Helper (GPU)")
+        );
+    }
+
+    /// The case that motivated this: a version-named binary under a
+    /// `versions/` directory. Every upgrade used to mint a new identity.
+    #[test]
+    fn version_named_binary_takes_the_project_name() {
+        assert_eq!(
+            n("/Users/matt/.local/share/claude/versions/2.1.219").as_deref(),
+            Some("claude")
+        );
+        assert_eq!(
+            n("/Users/matt/.local/share/claude/versions/2.1.220").as_deref(),
+            Some("claude"),
+            "different versions must resolve to the same identity"
+        );
+    }
+
+    #[test]
+    fn generic_directories_are_skipped_on_the_way_up() {
+        assert_eq!(
+            n("/opt/toolchain/releases/1.4.2/bin/3.2.1").as_deref(),
+            Some("toolchain")
+        );
+        assert_eq!(n("/srv/myapp/current/2.0").as_deref(), Some("myapp"));
+    }
+
+    #[test]
+    fn version_detection_is_conservative() {
+        assert!(looks_like_version("2.1.219"));
+        assert!(looks_like_version("v1.2.3"));
+        assert!(looks_like_version("1.0.0-rc1"));
+        assert!(looks_like_version("2"));
+        // Names, not versions — collapsing these would lose real identity.
+        assert!(!looks_like_version("python3.12"));
+        assert!(!looks_like_version("7z"));
+        assert!(!looks_like_version("curl"));
+        assert!(!looks_like_version("libexec2"));
+        assert!(!looks_like_version(""));
+        assert!(!looks_like_version("v"));
+    }
+
+    /// A version-named binary with nothing meaningful above it keeps the
+    /// version rather than resolving to something absurd like "/".
+    #[test]
+    fn version_with_no_meaningful_parent_falls_back_to_itself() {
+        assert_eq!(n("/2.1.219").as_deref(), Some("2.1.219"));
+        assert_eq!(n("/bin/1.0").as_deref(), Some("1.0"));
+    }
+
+    /// The live process is us, so this must resolve to the test binary.
+    #[test]
+    fn resolves_the_current_process() {
+        let pid = std::process::id();
+        let name = stable_name(pid).expect("own executable path is readable");
+        assert!(!name.is_empty());
+        assert!(
+            name.contains("netwatch"),
+            "expected the test binary, got {name:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_pid_yields_nothing() {
+        // Reserved as "no process" on both platforms; asking must fail
+        // cleanly rather than inventing a name.
+        assert!(executable_path(u32::MAX).is_none());
+    }
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -46,6 +46,8 @@ pub struct Theme {
 
 pub const THEME_NAMES: &[&str] = &[
     "dark",
+    // Defers every slot to the terminal's palette — see `terminal()`.
+    "terminal",
     "ocean",
     "solarized",
     "dracula",
@@ -67,6 +69,10 @@ pub fn by_name(name: &str) -> Theme {
         //               was deleted in v0.15.11 because its terminal-
         //               deferring behaviour duplicated `dark`.
         "light" | "minimal" => paper(),
+        // "system" and "ansi" are what users coming from other TUIs tend
+        // to reach for; accept both rather than silently falling back to
+        // dark and looking like the feature is missing.
+        "terminal" | "system" | "ansi" => terminal(),
         "ocean" => ocean(),
         "solarized" => solarized(),
         "dracula" => dracula(),
@@ -74,6 +80,61 @@ pub fn by_name(name: &str) -> Theme {
         "sky" => sky(),
         "paper" => paper(),
         _ => dark(),
+    }
+}
+
+/// Defers entirely to the terminal's own palette: ANSI slots 0–15 for
+/// color and `Color::Reset` for foreground and background, so whatever
+/// the user's terminal theme defines is what netwatch renders. Nothing
+/// here is a fixed RGB value — that is the whole point. Users running a
+/// system-wide theming setup (pywal, matugen, a terminal profile) get a
+/// netwatch that matches the rest of their desktop without maintaining a
+/// separate palette.
+///
+/// This is close to `dark`, which has always used ANSI named colors for
+/// most slots. The differences are the ones that matter for theme
+/// matching: `text_primary` is `Reset` (the terminal's exact configured
+/// foreground rather than its white slot), and the two selection
+/// backgrounds drop their fixed RGB for `Indexed(8)`.
+///
+/// One deliberate compromise: `selection_bg` / `highlight_bg` use
+/// `Indexed(8)` (bright black), the only slot conventionally rendered as
+/// a neutral mid-grey in both light and dark themes. A terminal theme
+/// that maps slot 8 very close to its background will show a faint
+/// selection bar; that is a property of the user's theme, and the
+/// alternative — a saturated color slot — is worse everywhere else.
+///
+/// Known gap: the chart dot-grid (`graph::render_grid`) still derives its
+/// color by interpolating a fixed grey toward `bg`. With `bg: Reset` the
+/// real background is unknown, so it assumes black and renders dark dots —
+/// invisible on dark terminals, too heavy on light ones. This predates
+/// this theme and affects every `bg: Reset` palette here (dark, ocean,
+/// solarized, dracula, nord); fixing it properly means giving `Theme` its
+/// own grid slot rather than inferring one.
+pub fn terminal() -> Theme {
+    Theme {
+        name: "terminal",
+        brand: Color::Cyan,
+        active_tab: Color::Yellow,
+        inactive_tab: Color::DarkGray,
+        border: Color::DarkGray,
+        separator: Color::DarkGray,
+        // Reset = the terminal's configured foreground, exactly.
+        text_primary: Color::Reset,
+        text_secondary: Color::Gray,
+        text_muted: Color::DarkGray,
+        text_inverse: Color::Black,
+        status_good: Color::Green,
+        status_warn: Color::Yellow,
+        status_error: Color::Red,
+        status_info: Color::Cyan,
+        rx_rate: Color::Green,
+        tx_rate: Color::Blue,
+        key_hint: Color::Yellow,
+        selection_bg: Color::Indexed(8),
+        highlight_bg: Color::Indexed(8),
+        // The reason this theme exists: never paint over the terminal.
+        bg: Color::Reset,
     }
 }
 
@@ -378,7 +439,7 @@ mod tests {
 
     #[test]
     fn theme_names_count() {
-        assert_eq!(THEME_NAMES.len(), 7);
+        assert_eq!(THEME_NAMES.len(), 8);
     }
 
     #[test]
@@ -394,12 +455,32 @@ mod tests {
     fn transparent_themes_leave_bg_reset() {
         // Existing six keep terminal-default bg so users who picked
         // their terminal palette deliberately don't have it stomped.
-        for name in ["dark", "ocean", "solarized", "dracula", "nord"] {
+        for name in ["dark", "terminal", "ocean", "solarized", "dracula", "nord"] {
             assert_eq!(
                 by_name(name).bg,
                 Color::Reset,
                 "{name} should be transparent"
             );
+        }
+    }
+
+    #[test]
+    fn terminal_theme_pins_no_rgb() {
+        // The entire contract of this theme is that every slot resolves
+        // through the terminal's own palette. Debug-formatting the whole
+        // struct checks every field at once, so a slot added later can't
+        // quietly acquire a fixed color without failing here.
+        let rendered = format!("{:?}", terminal());
+        assert!(
+            !rendered.contains("Rgb"),
+            "terminal theme must not pin RGB values: {rendered}"
+        );
+    }
+
+    #[test]
+    fn terminal_theme_accepts_common_aliases() {
+        for alias in ["terminal", "system", "ansi", "TERMINAL", "System"] {
+            assert_eq!(by_name(alias).name, "terminal", "alias {alias} failed");
         }
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -42,6 +42,41 @@ pub struct Theme {
     pub bg: Color,
 }
 
+impl Theme {
+    /// True when every slot resolves through the terminal's own palette
+    /// rather than fixed RGB. Effects that synthesize colors — the graph
+    /// fade, the chart grid — must switch off rather than emit 24-bit
+    /// values that ignore the user's theme.
+    pub fn defers_to_terminal(&self) -> bool {
+        self.name == "terminal"
+    }
+
+    /// Accent for UDP rows in the connections and stats tables.
+    ///
+    /// This isn't a `Theme` field because it predates the theme system and
+    /// every palette hardcoded the same value at the call site. Routing it
+    /// through here changes nothing for the existing themes and lets
+    /// `terminal` resolve it to an ANSI slot, which is what its
+    /// no-fixed-RGB guarantee requires.
+    pub fn proto_udp(&self) -> Color {
+        if self.defers_to_terminal() {
+            Color::Magenta
+        } else {
+            Color::Rgb(217, 122, 255)
+        }
+    }
+
+    /// Mid-severity amber, one step past `status_warn` but short of
+    /// `status_error` — used for RTT banding. Same story as `proto_udp`.
+    pub fn accent_amber(&self) -> Color {
+        if self.defers_to_terminal() {
+            Color::LightRed
+        } else {
+            Color::Rgb(255, 165, 0)
+        }
+    }
+}
+
 // ── Built-in themes ────────────────────────────────────────
 
 pub const THEME_NAMES: &[&str] = &[
@@ -104,13 +139,13 @@ pub fn by_name(name: &str) -> Theme {
 /// selection bar; that is a property of the user's theme, and the
 /// alternative — a saturated color slot — is worse everywhere else.
 ///
-/// Known gap: the chart dot-grid (`graph::render_grid`) still derives its
-/// color by interpolating a fixed grey toward `bg`. With `bg: Reset` the
-/// real background is unknown, so it assumes black and renders dark dots —
-/// invisible on dark terminals, too heavy on light ones. This predates
-/// this theme and affects every `bg: Reset` palette here (dark, ocean,
-/// solarized, dracula, nord); fixing it properly means giving `Theme` its
-/// own grid slot rather than inferring one.
+/// Effects that synthesize colors are switched off under this theme rather
+/// than allowed to emit 24-bit values it exists to avoid — see
+/// `defers_to_terminal`. That covers the graph fade, the chart dot-grid,
+/// and the insights card tints. Fade in particular interpolates in RGB and
+/// is applied across most of a frame, so leaving it on would have defeated
+/// the theme entirely (measured at 623 escapes per frame in syswatch, which
+/// shares this fade design).
 pub fn terminal() -> Theme {
     Theme {
         name: "terminal",

--- a/src/ui/connections.rs
+++ b/src/ui/connections.rs
@@ -689,7 +689,7 @@ fn render_conn_row(
     let proc_label = format!("{:<14} {:>5}", truncate(process, 14), pid_str);
 
     let proto_color = if conn.protocol.eq_ignore_ascii_case("UDP") {
-        Color::Rgb(217, 122, 255) // magenta-ish for UDP, matches mockup
+        t.proto_udp()
     } else {
         t.status_info
     };
@@ -811,7 +811,7 @@ fn render_conn_row(
     let faded_spans = if (row_alpha - 1.0).abs() < f32::EPSILON {
         spans
     } else {
-        crate::graph::fade_spans_fg(spans, t.bg, row_alpha)
+        crate::graph::fade_spans_fg(spans, t.bg, row_alpha, t.defers_to_terminal())
     };
     let line = Line::from(faded_spans);
 
@@ -1293,7 +1293,7 @@ fn format_hop_line(
             } else if *ms < 50.0 {
                 theme.status_warn
             } else if *ms < 100.0 {
-                Color::Rgb(255, 165, 0)
+                theme.accent_amber()
             } else {
                 theme.status_error
             }

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -719,7 +719,7 @@ fn render_top_connections(f: &mut Frame, app: &App, area: Rect) {
         // bottom-dim like the other tables when fade is on.
         let spans = if app.user_config.graph_fade && i > 0 {
             let alpha = crate::graph::row_fade_alpha(i, rendered_rows);
-            crate::graph::fade_spans_fg(spans, t.bg, alpha)
+            crate::graph::fade_spans_fg(spans, t.bg, alpha, t.defers_to_terminal())
         } else {
             spans
         };

--- a/src/ui/egress.rs
+++ b/src/ui/egress.rs
@@ -98,9 +98,13 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
     let mut total = 0usize;
 
     for profile in &profiles {
-        let mut dests: Vec<_> = profile.dests.values().collect();
-        dests.sort_by_key(|d| std::cmp::Reverse(d.count));
-        for dest in dests {
+        // Iterate entries, not values: the key's label is the destination's
+        // original identity (SNI, ASN org, or the IP) and is the only copy
+        // that survives when `last_ip` is missing — baselines written before
+        // the `ip` field existed, or rows an unreadable address blanked.
+        let mut dests: Vec<_> = profile.dests.iter().collect();
+        dests.sort_by_key(|(_, d)| std::cmp::Reverse(d.count));
+        for ((label, _), dest) in dests {
             total += 1;
             if total <= start || shown >= body_rows {
                 continue;
@@ -109,11 +113,24 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
             // Never hide the endpoint: a nameless row shows its real IP, not
             // a useless "(ip)" placeholder. Named rows show the name; the
             // concrete IP is always in its own column and in the export.
+            // The key label is the last resort — it repairs rows whose
+            // `last_ip` is blank without needing a migration.
             let name = match (&dest.sni, &dest.asn_org, dest.ech) {
                 (Some(s), _, _) => s.clone(),
                 (None, Some(a), _) => a.clone(),
                 (None, None, true) => "(ech — name encrypted)".to_string(),
-                (None, None, false) => dest.last_ip.clone(),
+                (None, None, false) if !dest.last_ip.is_empty() => dest.last_ip.clone(),
+                (None, None, false) => label.clone(),
+            };
+            // The label is only an address when neither name was recorded —
+            // otherwise it holds the SNI, and showing it here would put a
+            // hostname in the IP column. Same guard as `load_profiles`.
+            let ip_cell = if !dest.last_ip.is_empty() {
+                dest.last_ip.clone()
+            } else if dest.sni.is_none() && dest.asn_org.is_none() {
+                label.clone()
+            } else {
+                "—".to_string()
             };
             let (verdict, vstyle) = match app.egress_profiler.dest_allowed(&profile.process, dest) {
                 Some(true) => ("✓ ok", Style::default().fg(t.status_good)),
@@ -129,7 +146,7 @@ fn render_table(f: &mut Frame, app: &App, area: Rect) {
             let row = Row::new(vec![
                 Cell::from(profile.process.clone()).style(Style::default().fg(t.text_primary)),
                 Cell::from(name).style(Style::default().fg(t.text_primary)),
-                Cell::from(dest.last_ip.clone()).style(Style::default().fg(t.text_muted)),
+                Cell::from(ip_cell).style(Style::default().fg(t.text_muted)),
                 Cell::from(dest.port.to_string()).style(Style::default().fg(t.text_secondary)),
                 Cell::from(dest.count.to_string()).style(Style::default().fg(t.text_secondary)),
                 Cell::from(fmt_age(dest.first_seen, now)).style(Style::default().fg(t.text_muted)),

--- a/src/ui/insights.rs
+++ b/src/ui/insights.rs
@@ -439,7 +439,13 @@ fn render_card(f: &mut Frame, t: &crate::theme::Theme, area: Rect, card: &Card) 
 }
 
 fn card_bg(sev: Severity, t: &crate::theme::Theme) -> Color {
-    let _ = t;
+    // ANSI has no "slightly red background" — the nearest option is a
+    // full-intensity fill, far louder than the subtle card tint this is.
+    // Under the terminal theme the severity reads from the card's
+    // foreground instead, which is how terminal-native tools convey it.
+    if t.defers_to_terminal() {
+        return Color::Reset;
+    }
     match sev {
         Severity::Crit => Color::Rgb(0x3a, 0x1c, 0x1c),
         Severity::Warn => Color::Rgb(0x3a, 0x2c, 0x14),

--- a/src/ui/packets.rs
+++ b/src/ui/packets.rs
@@ -430,7 +430,12 @@ fn render_packet_list(f: &mut Frame, app: &App, packets: &[CapturedPacket], area
                 if (row_alpha - 1.0).abs() < f32::EPSILON {
                     s
                 } else if let Some(fg) = s.fg {
-                    s.fg(crate::graph::fade_color(fg, app.theme.bg, row_alpha))
+                    s.fg(crate::graph::fade_color(
+                        fg,
+                        app.theme.bg,
+                        row_alpha,
+                        app.theme.defers_to_terminal(),
+                    ))
                 } else {
                     s
                 }

--- a/src/ui/processes.rs
+++ b/src/ui/processes.rs
@@ -313,7 +313,12 @@ fn render_process_row(
     let line = if (row_alpha - 1.0).abs() < f32::EPSILON {
         line
     } else {
-        Line::from(crate::graph::fade_spans_fg(line.spans, t.bg, row_alpha))
+        Line::from(crate::graph::fade_spans_fg(
+            line.spans,
+            t.bg,
+            row_alpha,
+            t.defers_to_terminal(),
+        ))
     };
     f.render_widget(Paragraph::new(line).style(bg), row_area);
 }

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -423,7 +423,7 @@ fn render_breakdown_panel(
         ];
         let spans = if app.user_config.graph_fade {
             let alpha = crate::graph::row_fade_alpha(i, rendered);
-            crate::graph::fade_spans_fg(spans, t.bg, alpha)
+            crate::graph::fade_spans_fg(spans, t.bg, alpha, t.defers_to_terminal())
         } else {
             spans
         };
@@ -482,7 +482,7 @@ fn classify_protocol(p: &str) -> &'static str {
 fn protocol_palette(label: &str, t: &crate::theme::Theme) -> Color {
     match label {
         "TCP" => t.status_info,
-        "UDP" => Color::Rgb(217, 122, 255),
+        "UDP" => t.proto_udp(),
         "DNS" => t.status_good,
         "ICMP" => t.status_warn,
         "ARP" => t.brand,
@@ -623,7 +623,7 @@ fn remote_palette(t: &crate::theme::Theme) -> Vec<Color> {
         t.rx_rate,
         t.status_info,
         t.brand,
-        Color::Rgb(217, 122, 255),
+        t.proto_udp(),
     ]
 }
 

--- a/src/ui/topology.rs
+++ b/src/ui/topology.rs
@@ -681,7 +681,7 @@ fn render_hop_row(
     let rtt_color = match avg_rtt {
         Some(r) if r < 10.0 => t.status_good,
         Some(r) if r < 50.0 => t.status_warn,
-        Some(r) if r < 200.0 => Color::Rgb(255, 165, 0),
+        Some(r) if r < 200.0 => t.accent_amber(),
         Some(_) => t.status_error,
         None => t.text_muted,
     };


### PR DESCRIPTION
Fixes the reported symptom — **processes shown as `✗ drift` with no destination and no IP** — plus a larger false-drift source found while tracing it.

Reproduced against a real baseline: **9 of 118 destinations had an empty IP**, two profiles entirely so, and the violation text for those rows was literally `" not in allowlist"`.

## Blank destinations — four compounding defects

| # | Defect | Fix |
|---|---|---|
| 1 | `parse_addr_parts(":443")` returned `Some("")`, not `None` — only `"*"` mapped to `None` | Empty host is not a host. Also stops `build_connection_filter` pushing an empty term |
| 2 | `observe()` let it through: `is_private_ip("")` is `false`, so an empty IP cleared both guards | Explicit emptiness check |
| 3 | `upsert` overwrote `last_ip` unconditionally, so an unreadable address **downgraded a known IP** — why entries whose key label is a valid IP had `ip: ""` on disk | Only ever upgrade |
| 4 | `violation()` built `sni.or(asn).unwrap_or(ip)` → empty subject | `"unknown destination"` |

**Existing baselines repair themselves**, no migration. The destination key label is `sni.or(asn_org).unwrap_or(ip)`, so for a nameless destination it *is* the address it was learned from. `load_profiles` and the table fall back to it — guarded on neither name being present, so a hostname never lands in the IP column. This also covers baselines written before the `ip` field existed, where `#[serde(default)]` blanked every row.

## Split profiles — the bigger false-drift source

The same program was profiled twice. PKTAP carries a kernel-truncated `comm` (`MAXCOMLEN` on macOS, `TASK_COMM_LEN-1` on Linux); lsof reports the full name. Whichever attribution source won a tick decided the profile key:

| profile | dests | shared |
|---|---|---|
| `Google Chrome He` (16 bytes, PKTAP) | 16 | **7** |
| `Google Chrome Helper` (lsof) | 12 | |

So promoting one ratified a baseline the other's flows immediately drifted against — warn-on-drift failing against its own baseline.

Names now fold onto one key in either arrival order, at record time and once on load. **Only a name of exactly the truncation length is a candidate**, which keeps VS Code's real `Code Helper` (11 bytes) separate from the truncated `Code Helper (Plu`. Ambiguous prefixes resolve to the shortest match so the choice is stable across runs. Policy lookup tries both spellings; hit counts and violation tallies carry across the merge.

## Also

The per-process destination cap silently dropped entries at load — which resurfaces later as drift for traffic that is still happening. Now warns once per load with counts.

## Verification

Real baseline through the fixed code: **23 profiles / 118 dests / 9 blank → 22 / 110 / 4**. `Google Chrome He` merged; `Code Helper` correctly stayed separate. The remaining 4 are named destinations whose IP is genuinely unknown — they render `—` rather than a fabricated address and repopulate on the next flow.

10 regression tests, one per defect including the negative cases (short names never merge; label repair never puts a hostname in the IP field). 566 tests pass, `cargo fmt --check` clean, clippy warning count unchanged from baseline (58).

Full review: `~/Documents/netwatch-egress-review-2026-07-26.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011opuAtYif2s1QwYkNdJQvq