### PR TITLE
feat(egress+connections): grouped trees, policy add/remove, and the two policy-model criticals

### DIFF
--- a/docs/egress-linter-plan.md
+++ b/docs/egress-linter-plan.md
@@ -1,6 +1,14 @@
 # Plan: Horizon 3 — egress policy linter (observe → promote → warn)
 
 **Drafted:** 2026-07-04
+**Status (2026-07-28):** shipped through v0.27.0. Since then, on
+`feat/egress-tree-ux`: byte accounting, the grouped tree and the verdict
+vocabulary; on `feat/egress-policy-criticals`: the two policy-model criticals —
+strict mode for undeclared processes, and promotion no longer widening to an
+autonomous system (see the amended invariants below). Still open from the
+2026-07-28 analysis: `--egress-lint` breadth report, exec-path rule keys, CGNAT
++ IPv4-mapped private ranges, destination-scoped ports, metrics expansion.
+
 **Status (2026-07-04):** Phases 0–2 ✅ and **Phase 3 step 1 (OSS export) ✅**
 implemented on `feat/h3-egress-linter` (commits `bedd447` foundation, `777cb22`
 tab, `38a83bb` Phase 1, `1ea0d75` Phase 2, + NDJSON export), all unreleased —
@@ -18,12 +26,21 @@ uncommitted Egress tab (`src/ui/egress.rs` + wiring in app.rs/ui/mod.rs/widgets.
 
 **Invariants (hold in every phase):**
 - Warn, never block. No inline data path, no new capabilities held after init.
-- Deterministic and low-noise: only processes with a declared rule are checked;
-  a violation names the rule it broke.
+- Deterministic and low-noise: by default only processes with a declared rule
+  are checked, and a violation names the rule it broke. **Amended 2026-07-28:**
+  `strict = true` in the policy file opts into reporting *undeclared* processes
+  too. The default is unchanged; the opt-in exists because the thing a
+  compromise introduces is a new binary, which the default can never see.
 - The baseline is how you author the config (AppArmor-style profile generation,
   applied to egress). Resist iptables-in-TOML; let real use pull complexity.
-- SNI-first matching (cleartext ClientHello — no keylog required); ASN fallback;
-  never raw IP (CDN fronting makes IP rules noise).
+- SNI-first matching (cleartext ClientHello — no keylog required), then the
+  address. **Amended 2026-07-28:** promotion no longer falls back to the ASN.
+  An AS entry admits every host that AS operates, so learning one nameless
+  hyperscaler flow silently handed the process the whole hyperscaler — measured
+  at 12 of 25 rules on a real baseline. Rules match on ASN when a human writes
+  one; nothing generates one. The original "never raw IP" line was reversed
+  earlier (a nameless dest has no other identity, and would otherwise drift
+  against its own promoted rule); IP is the narrow choice, not the loose one.
 
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -850,6 +850,29 @@ impl App {
         self.ui.export_status_tick = 0;
     }
 
+    /// Collapse or expand the process under the cursor.
+    ///
+    /// Works from a destination row too — folding the group you are inside
+    /// is the common case, and requiring the user to first navigate up to
+    /// the header would be busywork.
+    fn toggle_egress_fold(&mut self) {
+        let Some(process) = crate::ui::egress::selected_process(self) else {
+            return;
+        };
+        if !self.ui.egress_collapsed.remove(&process) {
+            self.ui.egress_collapsed.insert(process.clone());
+            // Folding removes rows below the cursor; park it on the header
+            // so the selection stays on something visible.
+            let rows = crate::ui::egress::visible_rows(self);
+            if let Some(idx) = rows.iter().position(|r| {
+                matches!(r, crate::ui::egress::EgressRow::Process { profile, .. }
+                         if profile.process == process)
+            }) {
+                self.ui.scroll.egress_scroll = idx;
+            }
+        }
+    }
+
     /// Promote only the process under the cursor on the Egress tab —
     /// selective ratification, with a diff of what the promotion adds.
     fn promote_selected_egress(&mut self) {
@@ -1936,6 +1959,47 @@ fn handle_mouse(app: &mut App, mouse: crossterm::event::MouseEvent) {
                             app.ui.scroll.process_scroll = idx;
                         }
                     }
+                    Tab::Egress => {
+                        // Map against the same window the renderer computes,
+                        // not `scroll + visible_row` — that was issue #28 on
+                        // the Connections tab and the bug is identical here.
+                        let inner = crate::ui::egress::table_inner_area(area);
+                        if row < inner.y || row >= inner.y + inner.height {
+                            return;
+                        }
+                        let row_within = (row - inner.y) as usize;
+                        if row_within == 0 {
+                            return; // column-header row
+                        }
+                        let visible_row = row_within - 1;
+                        // Resolve the click to an index and whether that row
+                        // is a process header, then drop the borrow before
+                        // mutating — `visible_rows` borrows the whole App.
+                        let (idx, is_process) = {
+                            let rows = crate::ui::egress::visible_rows(app);
+                            if rows.is_empty() {
+                                return;
+                            }
+                            let body = inner.height.saturating_sub(1) as usize;
+                            let selected = app.ui.scroll.egress_scroll.min(rows.len() - 1);
+                            let start = (selected + 1).saturating_sub(body.max(1));
+                            let idx = (start + visible_row).min(rows.len() - 1);
+                            let is_process = matches!(
+                                rows.get(idx),
+                                Some(crate::ui::egress::EgressRow::Process { .. })
+                            );
+                            (idx, is_process)
+                        };
+                        app.ui.scroll.egress_scroll = idx;
+
+                        // Clicking the chevron folds the group. The glyph is
+                        // drawn at the first cell of a process row, so a
+                        // click in the leading two columns is unambiguous —
+                        // anywhere else just selects.
+                        if is_process && col <= inner.x + 1 {
+                            app.toggle_egress_fold();
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -2029,7 +2093,11 @@ fn scroll_tab(app: &mut App, delta: isize) {
             };
         }
         Tab::Egress => {
-            let max = app.egress_profiler.dest_count().saturating_sub(1);
+            // Clamp against the rows the tree actually draws — process rows
+            // plus the destinations of expanded groups — not the raw
+            // destination count, or the cursor runs off the end whenever a
+            // group is collapsed or a filter is applied.
+            let max = crate::ui::egress::visible_rows(app).len().saturating_sub(1);
             app.ui.scroll.egress_scroll = clamp_scroll(app.ui.scroll.egress_scroll, delta, max);
         }
         Tab::Dashboard => {}
@@ -2103,6 +2171,10 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
     }
     if app.ui.connection_filter_input && app.ui.current_tab == Tab::Connections {
         handle_connection_filter_input(app, key);
+        return false;
+    }
+    if app.ui.egress_filter_input && app.ui.current_tab == Tab::Egress {
+        handle_egress_filter_input(app, key);
         return false;
     }
     handle_main_key(app, key)
@@ -2357,6 +2429,44 @@ fn handle_connection_filter_input(app: &mut App, key: crossterm::event::KeyEvent
         }
         KeyCode::Char(c) => {
             app.ui.connection_filter_text.push(c);
+        }
+        _ => {}
+    }
+}
+
+fn handle_egress_filter_input(app: &mut App, key: crossterm::event::KeyEvent) {
+    match key.code {
+        KeyCode::Enter => {
+            app.ui.egress_filter_input = false;
+            app.ui.egress_filter_active = if app.ui.egress_filter_text.trim().is_empty() {
+                None
+            } else {
+                Some(app.ui.egress_filter_text.clone())
+            };
+            app.ui.scroll.egress_scroll = 0;
+        }
+        KeyCode::Esc => {
+            // Esc abandons the edit *and* the filter — matching the Procs
+            // tab, where Esc means "show me everything again".
+            app.ui.egress_filter_input = false;
+            app.ui.egress_filter_text.clear();
+            app.ui.egress_filter_active = None;
+            app.ui.scroll.egress_scroll = 0;
+        }
+        KeyCode::Backspace => {
+            app.ui.egress_filter_text.pop();
+            app.ui.egress_filter_active = if app.ui.egress_filter_text.is_empty() {
+                None
+            } else {
+                Some(app.ui.egress_filter_text.clone())
+            };
+            app.ui.scroll.egress_scroll = 0;
+        }
+        KeyCode::Char(c) => {
+            // Live-apply so the tree narrows as the user types.
+            app.ui.egress_filter_text.push(c);
+            app.ui.egress_filter_active = Some(app.ui.egress_filter_text.clone());
+            app.ui.scroll.egress_scroll = 0;
         }
         _ => {}
     }
@@ -2727,6 +2837,20 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
                 }
             }
             app.ui.export_status_tick = 0;
+        }
+        KeyCode::Char('s') if app.ui.current_tab == Tab::Egress => {
+            app.ui.egress_sort = app.ui.egress_sort.next();
+            app.ui.scroll.egress_scroll = 0;
+        }
+        KeyCode::Char('d') if app.ui.current_tab == Tab::Egress => {
+            app.ui.egress_detail = !app.ui.egress_detail;
+        }
+        KeyCode::Char('/') if app.ui.current_tab == Tab::Egress => {
+            app.ui.egress_filter_input = true;
+            app.ui.egress_filter_text = app.ui.egress_filter_active.clone().unwrap_or_default();
+        }
+        KeyCode::Char(' ') if app.ui.current_tab == Tab::Egress => {
+            app.toggle_egress_fold();
         }
         KeyCode::Char('s') => {
             let tab = app.ui.current_tab;

--- a/src/app.rs
+++ b/src/app.rs
@@ -907,6 +907,65 @@ impl App {
         self.ui.export_status_tick = 0;
     }
 
+    /// Ask before removing the selected process's rule. Answered by
+    /// `confirm_egress_removal` / `cancel_egress_removal`.
+    fn request_egress_removal(&mut self) {
+        let Some(process) = crate::ui::egress::selected_process(self) else {
+            self.ui.export_status = Some("Egress remove: nothing selected".into());
+            self.ui.export_status_tick = 0;
+            return;
+        };
+        // Nothing declared for it — say so now rather than after a pointless
+        // confirmation prompt.
+        if self.egress_profiler.declared_rule(&process).is_none() {
+            self.ui.export_status = Some(format!("{process} has no rule to remove"));
+            self.ui.export_status_tick = 0;
+            return;
+        }
+        self.ui.egress_pending_removal = Some(process);
+    }
+
+    fn cancel_egress_removal(&mut self) {
+        self.ui.egress_pending_removal = None;
+    }
+
+    /// Delete the confirmed process's rule from `egress-policy.toml` and
+    /// reload, so the tab reflects the file immediately.
+    ///
+    /// Under `strict = true` the process does not go quiet — it moves from
+    /// declared to `✗ undeclared`, which is the honest reading: coverage was
+    /// withdrawn, not granted.
+    fn confirm_egress_removal(&mut self) {
+        use crate::collectors::egress;
+        let Some(process) = self.ui.egress_pending_removal.take() else {
+            return;
+        };
+        let Some(path) = egress::default_policy_path() else {
+            self.ui.export_status = Some("Egress remove failed: no config dir".into());
+            self.ui.export_status_tick = 0;
+            return;
+        };
+        match egress::remove_rules_from_policy_file(std::slice::from_ref(&process), &path) {
+            Ok(removed) if removed.is_empty() => {
+                self.ui.export_status = Some(format!("{process} had no rule in the policy file"));
+            }
+            Ok(_) => {
+                let loaded = egress::load_policy_file(&path);
+                let ok = loaded.is_some();
+                self.egress_profiler.set_policy(loaded);
+                self.ui.export_status = Some(if ok {
+                    format!("Removed {process} from policy — no longer checked")
+                } else {
+                    format!("Removed {process} but reload failed — check file permissions")
+                });
+            }
+            Err(e) => {
+                self.ui.export_status = Some(format!("Egress remove failed: {e}"));
+            }
+        }
+        self.ui.export_status_tick = 0;
+    }
+
     fn disarm_incident_recorder(&mut self) {
         self.incident_recorder.disarm();
         if self.incident_capture_started && self.packet_collector.is_capturing() {
@@ -2177,7 +2236,29 @@ fn handle_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
         handle_egress_filter_input(app, key);
         return false;
     }
+    // Ahead of `handle_main_key`, so the confirmation swallows `y` before the
+    // yank binding sees it — and so any other key cancels rather than doing
+    // something unrelated while a destructive prompt is on screen.
+    if app.ui.egress_pending_removal.is_some() && app.ui.current_tab == Tab::Egress {
+        if confirms_removal(key.code) {
+            app.confirm_egress_removal();
+        } else {
+            app.cancel_egress_removal();
+        }
+        return false;
+    }
     handle_main_key(app, key)
+}
+
+/// Whether a key answers "yes" to the egress removal prompt.
+///
+/// Only an explicit yes counts; everything else cancels, so a stray keystroke
+/// against a destructive prompt is always the safe outcome. `Enter` is
+/// deliberately *not* a yes — on this tab it is the add-to-policy binding, and
+/// a key that adds in one state and deletes in another is how people delete
+/// things they meant to keep.
+fn confirms_removal(code: KeyCode) -> bool {
+    matches!(code, KeyCode::Char('y') | KeyCode::Char('Y'))
 }
 
 fn handle_help_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
@@ -2852,6 +2933,12 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
         KeyCode::Char(' ') if app.ui.current_tab == Tab::Egress => {
             app.toggle_egress_fold();
         }
+        // Must stay ahead of the unguarded `s`/`S` sort arms below — match
+        // arms are ordered, and a guarded Egress arm placed after an
+        // unguarded one silently never fires.
+        KeyCode::Char('x') | KeyCode::Delete if app.ui.current_tab == Tab::Egress => {
+            app.request_egress_removal();
+        }
         KeyCode::Char('s') => {
             let tab = app.ui.current_tab;
             let keys = sort_columns_for_tab(tab);
@@ -3094,6 +3181,25 @@ mod tests {
             app_protocol: None,
             retransmits: 0,
             out_of_order: 0,
+        }
+    }
+
+    /// Only an explicit yes deletes a policy rule. In particular `Enter` must
+    /// not — it is the add-to-policy key on this same tab, and one keystroke
+    /// meaning both "add" and "delete" is a trap.
+    #[test]
+    fn only_an_explicit_yes_confirms_a_policy_removal() {
+        assert!(confirms_removal(KeyCode::Char('y')));
+        assert!(confirms_removal(KeyCode::Char('Y')));
+        for code in [
+            KeyCode::Enter,
+            KeyCode::Esc,
+            KeyCode::Char('n'),
+            KeyCode::Char('x'),
+            KeyCode::Char('q'),
+            KeyCode::Down,
+        ] {
+            assert!(!confirms_removal(code), "{code:?} must not delete a rule");
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -859,8 +859,7 @@ impl App {
         let Some(process) = crate::ui::egress::selected_process(self) else {
             return;
         };
-        if !self.ui.egress_collapsed.remove(&process) {
-            self.ui.egress_collapsed.insert(process.clone());
+        if crate::ui::tree::toggle(&mut self.ui.egress_collapsed, &process) {
             // Folding removes rows below the cursor; park it on the header
             // so the selection stays on something visible.
             let rows = crate::ui::egress::visible_rows(self);
@@ -869,6 +868,29 @@ impl App {
                          if profile.process == process)
             }) {
                 self.ui.scroll.egress_scroll = idx;
+            }
+        }
+    }
+
+    /// Collapse or expand the connection group under the cursor.
+    ///
+    /// Works from a child row as well as the header — folding the group you
+    /// are inside is the common case, and making the user navigate up first
+    /// would be busywork. Same behaviour as the Egress tab, deliberately.
+    fn toggle_connection_fold(&mut self) {
+        let Some(key) = crate::ui::connections::selected_group_key(self) else {
+            return;
+        };
+        if crate::ui::tree::toggle(&mut self.ui.connection_collapsed, &key) {
+            // Collapsing removes the rows below the cursor, so park it on the
+            // header to keep the selection on something visible.
+            let view = crate::ui::connections::build_view(self);
+            let rows = view.rows(&self.ui.connection_collapsed);
+            if let Some(idx) = rows.iter().position(|r| {
+                matches!(r, crate::ui::connections::ConnRow::Parent { group, .. }
+                         if group.key == key)
+            }) {
+                self.ui.scroll.connection_scroll = idx;
             }
         }
     }
@@ -1957,20 +1979,43 @@ fn handle_mouse(app: &mut App, mouse: crossterm::event::MouseEvent) {
                         }
                         let visible_row = row_within - 1;
 
-                        let conns = crate::ui::connections::filtered_sorted_conns(app);
-                        if conns.is_empty() {
+                        // Against the *row* list, not the connection list —
+                        // under a group mode those differ by the header rows,
+                        // and indexing the wrong one is issue #28 again.
+                        let view = crate::ui::connections::build_view(app);
+                        let rows = view.rows(&app.ui.connection_collapsed);
+                        if rows.is_empty() {
                             return;
                         }
                         let visible_rows = inner.height.saturating_sub(1) as usize;
-                        let max_idx = conns.len().saturating_sub(1);
+                        let max_idx = rows.len().saturating_sub(1);
                         let selected = app.ui.scroll.connection_scroll.min(max_idx);
                         let window_top = crate::ui::connections::compute_window_top(
                             selected,
-                            conns.len(),
+                            rows.len(),
                             visible_rows,
                         );
                         let idx = (window_top + visible_row).min(max_idx);
+                        // Clicking a header folds it, matching the Egress
+                        // tab's chevron behaviour.
+                        let clicked_header = matches!(
+                            rows.get(idx),
+                            Some(crate::ui::connections::ConnRow::Parent { .. })
+                        );
+                        let key = match rows.get(idx) {
+                            Some(crate::ui::connections::ConnRow::Parent { group, .. }) => {
+                                Some(group.key.clone())
+                            }
+                            _ => None,
+                        };
+                        drop(rows);
+                        drop(view);
                         app.ui.scroll.connection_scroll = idx;
+                        if clicked_header {
+                            if let Some(k) = key {
+                                crate::ui::tree::toggle(&mut app.ui.connection_collapsed, &k);
+                            }
+                        }
                     }
                     Tab::Packets if !app.ui.stream_view_open => {
                         if clicked_row > 0 {
@@ -2090,11 +2135,10 @@ fn scroll_tab(app: &mut App, delta: isize) {
                 app.ui.scroll.traceroute_scroll =
                     clamp_scroll(app.ui.scroll.traceroute_scroll, delta, usize::MAX);
             } else {
-                // Clamp against the filtered list so PgDn/arrows can't
-                // land on rows the user isn't seeing (issue #26).
-                let max = crate::ui::connections::filtered_sorted_conns(app)
-                    .len()
-                    .saturating_sub(1);
+                // Clamp against the visible rows so PgDn/arrows can't land
+                // on rows the user isn't seeing (issue #26) — which under a
+                // group mode means rows including headers, not connections.
+                let max = crate::ui::connections::visible_row_count(app).saturating_sub(1);
                 app.ui.scroll.connection_scroll =
                     clamp_scroll(app.ui.scroll.connection_scroll, delta, max);
             }
@@ -2843,9 +2887,9 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
             }
         }
         KeyCode::Char('W') if app.ui.current_tab == Tab::Connections => {
-            // Operate on what the user sees, not the unfiltered list.
-            let conns = crate::ui::connections::filtered_sorted_conns(app);
-            if let Some(conn) = conns.get(app.ui.scroll.connection_scroll) {
+            // Operate on what the user sees, not the unfiltered list — and
+            // on a connection, never a group header.
+            if let Some(conn) = crate::ui::connections::selected_connection(app) {
                 let (remote_ip, _) = parse_addr_parts(&conn.remote_addr);
                 if let Some(ip) = remote_ip {
                     app.whois_cache.request(&ip);
@@ -2855,8 +2899,7 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
         KeyCode::Char('T')
             if app.ui.current_tab == Tab::Connections && !app.ui.traceroute_view_open =>
         {
-            let conns = crate::ui::connections::filtered_sorted_conns(app);
-            if let Some(conn) = conns.get(app.ui.scroll.connection_scroll) {
+            if let Some(conn) = crate::ui::connections::selected_connection(app) {
                 let (remote_ip, _) = parse_addr_parts(&conn.remote_addr);
                 if let Some(ip) = remote_ip {
                     app.traceroute_runner.run(&ip);
@@ -2933,6 +2976,9 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
         KeyCode::Char(' ') if app.ui.current_tab == Tab::Egress => {
             app.toggle_egress_fold();
         }
+        KeyCode::Char(' ') if app.ui.current_tab == Tab::Connections => {
+            app.toggle_connection_fold();
+        }
         // Must stay ahead of the unguarded `s`/`S` sort arms below — match
         // arms are ordered, and a guarded Egress arm placed after an
         // unguarded one silently never fires.
@@ -2987,9 +3033,14 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
             }
         }
         KeyCode::Enter if app.ui.current_tab == Tab::Connections => {
-            let conns = crate::ui::connections::filtered_sorted_conns(app);
-            if let Some(conn) = conns.get(app.ui.scroll.connection_scroll) {
-                let filter = build_connection_filter(conn);
+            // A group header has no single flow to drill into, so Enter does
+            // the other obvious thing there rather than nothing at all.
+            let Some(conn) = crate::ui::connections::selected_connection(app) else {
+                app.toggle_connection_fold();
+                return false;
+            };
+            {
+                let filter = build_connection_filter(&conn);
                 app.ui.packet_filter_text = filter.clone();
                 app.ui.packet_filter_active = Some(filter);
                 app.ui.packet_filter_input = false;

--- a/src/app.rs
+++ b/src/app.rs
@@ -859,7 +859,7 @@ impl App {
         let Some(process) = crate::ui::egress::selected_process(self) else {
             return;
         };
-        if crate::ui::tree::toggle(&mut self.ui.egress_collapsed, &process) {
+        if self.ui.egress_collapsed.toggle(&process) {
             // Folding removes rows below the cursor; park it on the header
             // so the selection stays on something visible.
             let rows = crate::ui::egress::visible_rows(self);
@@ -881,7 +881,7 @@ impl App {
         let Some(key) = crate::ui::connections::selected_group_key(self) else {
             return;
         };
-        if crate::ui::tree::toggle(&mut self.ui.connection_collapsed, &key) {
+        if self.ui.connection_collapsed.toggle(&key) {
             // Collapsing removes the rows below the cursor, so park it on the
             // header to keep the selection on something visible.
             let view = crate::ui::connections::build_view(self);
@@ -2013,7 +2013,7 @@ fn handle_mouse(app: &mut App, mouse: crossterm::event::MouseEvent) {
                         app.ui.scroll.connection_scroll = idx;
                         if clicked_header {
                             if let Some(k) = key {
-                                crate::ui::tree::toggle(&mut app.ui.connection_collapsed, &k);
+                                app.ui.connection_collapsed.toggle(&k);
                             }
                         }
                     }
@@ -2455,6 +2455,34 @@ fn handle_settings_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
                 app.ui.settings_status = Some(format!(
                     "Graph fade: {}",
                     if app.user_config.graph_fade {
+                        "on"
+                    } else {
+                        "off"
+                    }
+                ));
+                app.ui.settings_status_tick = 0;
+            }
+            KeyCode::Left
+            | KeyCode::Right
+            | KeyCode::Char('h')
+            | KeyCode::Char('l')
+            | KeyCode::Char(' ')
+                if app.ui.settings_cursor == ui::settings::cursor::GROUPS_COLLAPSED =>
+            {
+                app.user_config.groups_start_collapsed = !app.user_config.groups_start_collapsed;
+                // Apply to the live screens too. A preference that only takes
+                // effect next launch reads as a broken toggle when the tab
+                // behind the overlay visibly disagrees with it.
+                if app.user_config.groups_start_collapsed {
+                    app.ui.egress_collapsed.collapse_all();
+                    app.ui.connection_collapsed.collapse_all();
+                } else {
+                    app.ui.egress_collapsed.expand_all();
+                    app.ui.connection_collapsed.expand_all();
+                }
+                app.ui.settings_status = Some(format!(
+                    "Groups start folded: {}",
+                    if app.user_config.groups_start_collapsed {
                         "on"
                     } else {
                         "off"
@@ -2978,6 +3006,24 @@ fn handle_main_key(app: &mut App, key: crossterm::event::KeyEvent) -> bool {
         }
         KeyCode::Char(' ') if app.ui.current_tab == Tab::Connections => {
             app.toggle_connection_fold();
+        }
+        // Fold/unfold everything. One key rather than two because the state
+        // is binary at the screen level: either you want the overview or you
+        // want the detail. Resets the cursor, since the row it pointed at has
+        // almost certainly moved.
+        KeyCode::Char('z') if app.ui.current_tab == Tab::Egress => {
+            let collapsed = app.ui.egress_collapsed.toggle_all();
+            app.ui.scroll.egress_scroll = 0;
+            app.ui.export_status = Some(if collapsed {
+                "Folded all processes".into()
+            } else {
+                "Expanded all processes".into()
+            });
+            app.ui.export_status_tick = 0;
+        }
+        KeyCode::Char('z') if app.ui.current_tab == Tab::Connections => {
+            app.ui.connection_collapsed.toggle_all();
+            app.ui.scroll.connection_scroll = 0;
         }
         // Must stay ahead of the unguarded `s`/`S` sort arms below — match
         // arms are ordered, and a guarded Egress arm placed after an

--- a/src/collectors/egress.rs
+++ b/src/collectors/egress.rs
@@ -49,6 +49,15 @@ const VIOLATION_COOLDOWN_SECS: u64 = 300;
 const STALE_DEST_SECS: u64 = 30 * 24 * 3600;
 /// Write the learned baseline to disk at most this often (plus once at quit).
 const PERSIST_INTERVAL_SECS: u64 = 60;
+/// Under `strict = true`, how many observation ticks (~1 s each) a process
+/// must persist before its lack of a rule is reported.
+///
+/// Set low on purpose. The noise it exists to suppress is a fork storm of
+/// short-lived build tooling, each member appearing for a single tick; the
+/// thing it must *not* suppress is a burst of exfiltration, which cannot
+/// move meaningful volume in under a few seconds. Erring high would trade
+/// the feature's whole point for tidiness.
+const UNDECLARED_SETTLE_TICKS: u64 = 3;
 /// Schema tag stamped on the NDJSON export's `_meta` line. Bump the minor
 /// when adding fields (additive/back-compatible), the major on a breaking
 /// change — the managed ingest keys off this.
@@ -139,6 +148,11 @@ pub enum Verdict {
     /// `NoPolicy` — here the operator has a policy and simply never declared
     /// this program.
     NoRule,
+    /// The process has no rule and the policy claims to be complete
+    /// (`strict = true`), so the absence *is* the finding. Distinct from
+    /// `NoRule`, which is the same fact without the claim: unchecked versus
+    /// checked-and-unexpected.
+    Undeclared,
     /// No policy loaded at all; observe-only.
     NoPolicy,
 }
@@ -153,13 +167,17 @@ impl Verdict {
             Verdict::Ech => "? ech",
             Verdict::Drift => "\u{2717} drift",
             Verdict::NoRule => "\u{2014} no rule",
+            Verdict::Undeclared => "\u{2717} undeclared",
             Verdict::NoPolicy => "\u{2014}",
         }
     }
     /// True for states the operator should look at: broad matches and
     /// outright drift. Drives colour and the header tally.
     pub fn is_notable(&self) -> bool {
-        matches!(self, Verdict::Asn(_) | Verdict::Drift | Verdict::NoRule)
+        matches!(
+            self,
+            Verdict::Asn(_) | Verdict::Drift | Verdict::NoRule | Verdict::Undeclared
+        )
     }
 }
 
@@ -192,7 +210,8 @@ pub struct EgressRecord {
     pub last_seen: u64,
     pub count: u64,
     /// Policy verdict at export time: `ok` | `drift` | `unreadable` (ECH,
-    /// name hidden) | `unchecked` (no rule for this process).
+    /// name hidden) | `unchecked` (no rule for this process, observe mode) |
+    /// `undeclared` (no rule, under a policy declaring itself complete).
     pub verdict: String,
     /// Which dimension admitted an `ok` verdict — `sni` | `ip` | `asn`.
     /// `None` for anything not admitted.
@@ -365,9 +384,12 @@ impl EgressProfiler {
             .retain(|_, &mut t| now.duration_since(t) < cooldown);
     }
 
-    /// Compare one observed flow against the loaded policy. Only processes
-    /// that *have* a declared rule are checked — an unlisted process has no
-    /// rule to violate, so it never warns (deterministic, low-noise). A new
+    /// Compare one observed flow against the loaded policy.
+    ///
+    /// By default only processes that *have* a declared rule are checked — an
+    /// unlisted process has no rule to violate, so it never warns
+    /// (deterministic, low-noise). Under `strict = true` the policy claims to
+    /// be complete, so an undeclared process is itself the finding. A new
     /// violation is queued (subject to the per-flow cooldown).
     #[allow(clippy::too_many_arguments)]
     fn check_policy(
@@ -386,18 +408,29 @@ impl EgressProfiler {
         // under the truncated `comm` still matches a rule declared under the
         // full name (and vice versa). Computed before borrowing the policy.
         let canonical = self.canonical_process(process);
+        // Under strict mode, has this process been around long enough to be
+        // worth reporting? Computed before the policy borrow.
+        let settled = self.process_is_settled(process);
         let Some(policy) = &self.policy else {
             return;
         };
-        let Some(rule) = policy
+        let rule = policy
             .process
             .get(process)
-            .or_else(|| policy.process.get(canonical.as_str()))
-        else {
-            return;
-        };
-        let Some(mut reason) = rule.violation(sni.as_deref(), asn_org.as_deref(), ip, port) else {
-            return;
+            .or_else(|| policy.process.get(canonical.as_str()));
+        let mut reason = match rule {
+            Some(rule) => match rule.violation(sni.as_deref(), asn_org.as_deref(), ip, port) {
+                Some(r) => r,
+                None => return,
+            },
+            // No rule. In observe mode that is silence by design; in strict
+            // mode it is the whole point of the feature.
+            None => {
+                if !policy.strict || !settled {
+                    return;
+                }
+                format!("{process} has no rule in the egress policy")
+            }
         };
         // An ECH flow's inner SNI is hidden by design — the miss may be
         // "name unreadable", not real drift. Say so in the alert.
@@ -437,6 +470,19 @@ impl EgressProfiler {
         self.recent.truncate(RECENT_VIOLATIONS_CAP);
     }
 
+    /// Whether a process has been observed long enough for strict mode to
+    /// report it as undeclared.
+    ///
+    /// `count` is dwell in observation ticks, so the longest-lived
+    /// destination is how long the process has been talking. Because the
+    /// baseline persists, a program seen for hours in a previous session is
+    /// settled immediately on restart — which is right: it is not new.
+    fn process_is_settled(&self, process: &str) -> bool {
+        self.profiles
+            .get(process)
+            .is_some_and(|p| p.dests.values().any(|d| d.count >= UNDECLARED_SETTLE_TICKS))
+    }
+
     /// Recent violations retained for the on-screen warnings panel, newest
     /// first. Independent of `take_violations` (which drains the alert feed).
     pub fn recent_violations(&self) -> impl Iterator<Item = &RecentViolation> {
@@ -467,7 +513,9 @@ impl EgressProfiler {
             // ECH is a policy *miss* whose cause is an encrypted name. It
             // stays `false` here so the export keeps reporting it as
             // "unreadable"; only the presentation differs from real drift.
-            Verdict::Drift | Verdict::Ech => Some(false),
+            // `Undeclared` is a miss too — under a policy that claims to be
+            // complete, "no rule" is a finding rather than a blind spot.
+            Verdict::Drift | Verdict::Ech | Verdict::Undeclared => Some(false),
             _ => Some(true),
         }
     }
@@ -489,7 +537,13 @@ impl EgressProfiler {
             .get(process)
             .or_else(|| policy.process.get(canonical.as_str()))
         else {
-            return Verdict::NoRule;
+            // Same fact, two readings: unchecked when the policy is partial,
+            // a finding when it claims to be complete.
+            return if policy.strict {
+                Verdict::Undeclared
+            } else {
+                Verdict::NoRule
+            };
         };
         if rule
             .violation(
@@ -872,6 +926,11 @@ impl EgressProfiler {
                 let verdict = match &v {
                     Verdict::Ech => "unreadable",
                     Verdict::Drift => "drift",
+                    // Its own value, not folded into `drift`: nothing was
+                    // compared, so calling it drift would overstate what the
+                    // linter knows. A consumer that wants findings takes
+                    // `drift | undeclared`.
+                    Verdict::Undeclared => "undeclared",
                     Verdict::NoRule | Verdict::NoPolicy => "unchecked",
                     _ => "ok",
                 }
@@ -1104,26 +1163,50 @@ impl EgressProfiler {
     }
 }
 
+/// Whether an ASN org string names an actual organisation.
+///
+/// The geo database uses `Unassigned` as its *failure* label, and a lookup
+/// that finds nothing yields an empty string. Allowlisting either admits
+/// every destination whose ASN lookup failed — the opposite of an allowlist.
+/// Checked wherever a rule is generated; a hand-written policy is still
+/// honoured verbatim, because the file should do what it says.
+fn is_identifying_asn(org: &str) -> bool {
+    let t = org.trim();
+    !t.is_empty() && !t.eq_ignore_ascii_case("unassigned") && !t.eq_ignore_ascii_case("unknown")
+}
+
 /// Build the allowlist rule a profile's observations imply.
+///
+/// Promotion never widens a rule to an autonomous system. An ASN match
+/// admits everything that AS operates — for a hyperscaler, effectively the
+/// whole internet — so learning one nameless Google flow would have handed
+/// the process every host Google runs, permanently and invisibly. Identity
+/// is taken from the SNI where there is one and the address otherwise; an
+/// ASN entry is only ever reached when a destination has *no* other
+/// identity at all, and even then only if the org actually names someone.
+/// Widening to an AS remains available, but as a deliberate hand edit.
 fn rule_from_profile(profile: &EgressProfile) -> ProcessRule {
     let mut allow_sni = BTreeSet::new();
     let mut allow_asn = BTreeSet::new();
     let mut allow_ip = BTreeSet::new();
     let mut allow_ports = BTreeSet::new();
     for dest in profile.dests.values() {
-        match (&dest.sni, &dest.asn_org) {
-            (Some(s), _) => {
+        match &dest.sni {
+            Some(s) => {
                 allow_sni.insert(s.clone());
             }
-            (None, Some(a)) => {
-                allow_asn.insert(a.clone());
-            }
-            // No name at all: the IP is the only identity we have, so admit
-            // it by IP — otherwise this dest would drift against its own
-            // promoted rule the moment a sibling dest contributed an SNI.
-            (None, None) => {
+            // No readable name: the address is the precise identity we have,
+            // so admit that. This also keeps a promoted baseline admitting
+            // its own members — without it a nameless dest would drift
+            // against its own rule the moment a sibling contributed an SNI.
+            None => {
                 if !dest.last_ip.is_empty() {
                     allow_ip.insert(dest.last_ip.clone());
+                } else if let Some(a) = dest.asn_org.as_deref().filter(|a| is_identifying_asn(a)) {
+                    // Neither name nor address survived. The AS is the last
+                    // identity left, and admitting it beats emitting a rule
+                    // that flags its own baseline.
+                    allow_asn.insert(a.to_string());
                 }
             }
         }
@@ -1195,6 +1278,21 @@ pub fn default_profiles_path() -> Option<PathBuf> {
 /// it — a sentence no firewall ruleset can express. It never blocks.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct EgressPolicy {
+    /// Treat the policy as *complete*: a process with no rule is a finding,
+    /// not a blind spot. Off by default, because it is only meaningful once
+    /// the operator believes they have declared everything.
+    ///
+    /// This is the difference between "netwatch tells me when my declared
+    /// software misbehaves" and "netwatch tells me when something is
+    /// exfiltrating". Without it the linter cannot see the one thing a
+    /// compromise actually introduces — a binary nobody declared — because
+    /// an undeclared process has no rule to violate and so warns never.
+    ///
+    /// Lives in the policy file rather than config.toml deliberately: it is
+    /// a claim about *this policy*, travels with it, and is meaningless
+    /// without one.
+    #[serde(default)]
+    pub strict: bool,
     #[serde(default)]
     pub process: HashMap<String, ProcessRule>,
 }
@@ -1385,7 +1483,16 @@ fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 
 const POLICY_HEADER: &str = "# netwatch egress policy (observe → promote → warn).\n\
                              # Generated from the observed baseline; review before trusting.\n\
-                             # The linter WARNS on drift — it never blocks.\n\n";
+                             # The linter WARNS on drift — it never blocks.\n\
+                             #\n\
+                             # strict = true treats this policy as complete: any process\n\
+                             # WITHOUT a rule below is then reported as undeclared. Off by\n\
+                             # default. Turn it on once you believe the list is complete —\n\
+                             # it is what lets the linter see a binary nobody declared.\n\
+                             #\n\
+                             # Promotion never writes allow_asn from an observation: an AS\n\
+                             # entry admits every host that AS operates. Widen by hand if\n\
+                             # you mean it.\n\n";
 
 /// Union the string entries already declared under `key` in an existing
 /// TOML process table with the newly-promoted ones. Deduped, sorted, stable.
@@ -1761,8 +1868,12 @@ mod tests {
         let chrome = policy.process.get("chrome").unwrap();
         assert!(chrome.allow_sni.contains(&"www.google.com".to_string()));
         assert_eq!(chrome.allow_ports, vec![443]);
+        // A nameless destination is promoted by *address*, never by its
+        // autonomous system — admitting all of Quad9 is not what observing
+        // one Quad9 address means.
         let curl = policy.process.get("curl").unwrap();
-        assert!(curl.allow_asn.contains(&"Quad9".to_string()));
+        assert!(curl.allow_ip.contains(&"9.9.9.9".to_string()));
+        assert!(curl.allow_asn.is_empty());
 
         // The promoted policy must not flag the very baseline it came from.
         assert!(chrome
@@ -1772,6 +1883,9 @@ mod tests {
                 "142.250.1.1",
                 443
             )
+            .is_none());
+        assert!(curl
+            .violation(None, Some("Quad9"), "9.9.9.9", 443)
             .is_none());
     }
 
@@ -2906,6 +3020,227 @@ mod verdict_tests {
             ),
             Verdict::Drift
         );
+    }
+
+    /// Under a policy that declares itself complete, the same absence is a
+    /// finding rather than a blind spot — and must not be confused with
+    /// drift, which is a *declared* process going somewhere new.
+    #[test]
+    fn strict_mode_reports_an_undeclared_process_as_a_finding() {
+        let mut p = profiler(rule(&["api.example.com"], &[], &[], &[]));
+        let mut policy = p.policy.clone().unwrap();
+        policy.strict = true;
+        p.set_policy(Some(policy));
+
+        let v = p.verdict("other", &dest(Some("anything.com"), None, "9.9.9.9", false));
+        assert_eq!(v, Verdict::Undeclared);
+        assert!(v.is_notable());
+        assert_ne!(v, Verdict::Drift, "nothing was compared — don't say drift");
+        assert_eq!(
+            p.dest_allowed("other", &dest(Some("anything.com"), None, "9.9.9.9", false)),
+            Some(false),
+            "strict turns 'unchecked' into 'not allowed'"
+        );
+        // A process that IS declared is unaffected.
+        assert_eq!(
+            p.verdict(
+                "app",
+                &dest(Some("api.example.com"), None, "1.2.3.4", false)
+            ),
+            Verdict::Sni
+        );
+    }
+
+    /// Strict mode is opt-in: the same profiler without the flag stays silent
+    /// about processes it was never told about.
+    #[test]
+    fn strict_is_off_by_default_and_observe_mode_stays_silent() {
+        let mut p = profiler(rule(&["api.example.com"], &[], &[], &[]));
+        assert!(!p.policy.as_ref().unwrap().strict);
+        let now = Instant::now();
+        for _ in 0..10 {
+            p.record_flow(
+                "unknown",
+                "203.0.113.9",
+                443,
+                sni("evil.example.com"),
+                None,
+                false,
+                SystemTime::now(),
+                0,
+                0,
+            );
+            p.check_policy(
+                "unknown",
+                "203.0.113.9",
+                443,
+                &sni("evil.example.com"),
+                &None,
+                false,
+                now,
+            );
+        }
+        assert!(
+            p.take_violations().is_empty(),
+            "observe mode must not warn about an undeclared process"
+        );
+    }
+
+    /// The warning strict mode exists to produce, plus the settle threshold
+    /// that keeps a fork storm of one-tick build tooling from storming.
+    #[test]
+    fn strict_warns_on_an_undeclared_process_once_it_has_settled() {
+        let mut p = profiler(rule(&["api.example.com"], &[], &[], &[]));
+        let mut policy = p.policy.clone().unwrap();
+        policy.strict = true;
+        p.set_policy(Some(policy));
+        p.set_violation_cooldown(0);
+        let now = Instant::now();
+
+        let step = |p: &mut EgressProfiler| {
+            p.record_flow(
+                "backdoor",
+                "203.0.113.9",
+                443,
+                sni("evil.example.com"),
+                None,
+                false,
+                SystemTime::now(),
+                0,
+                0,
+            );
+            p.check_policy(
+                "backdoor",
+                "203.0.113.9",
+                443,
+                &sni("evil.example.com"),
+                &None,
+                false,
+                now,
+            );
+        };
+
+        // A single-tick appearance is below the settle threshold.
+        step(&mut p);
+        assert!(
+            p.take_violations().is_empty(),
+            "a one-tick process must not warn"
+        );
+
+        // Sustained presence crosses it.
+        for _ in 0..UNDECLARED_SETTLE_TICKS {
+            step(&mut p);
+        }
+        let v = p.take_violations();
+        assert!(!v.is_empty(), "a settled undeclared process must warn");
+        assert_eq!(v[0].process, "backdoor");
+        assert!(
+            v[0].reason.contains("no rule"),
+            "the reason must name the actual finding, got {:?}",
+            v[0].reason
+        );
+        assert_eq!(
+            p.violation_totals_sorted()
+                .iter()
+                .find(|(n, _)| n == "backdoor")
+                .map(|(_, c)| *c),
+            Some(v.len() as u64),
+            "strict findings feed the same violation counter as drift"
+        );
+    }
+
+    /// Strict findings export under their own verdict rather than being
+    /// folded into `drift` — the consumer should be able to tell "went
+    /// somewhere new" from "was never accounted for".
+    #[test]
+    fn strict_finding_exports_as_undeclared() {
+        let mut p = profiler(rule(&["api.example.com"], &[], &[], &[]));
+        let mut policy = p.policy.clone().unwrap();
+        policy.strict = true;
+        p.set_policy(Some(policy));
+        p.record_flow(
+            "backdoor",
+            "203.0.113.9",
+            443,
+            sni("evil.example.com"),
+            None,
+            false,
+            SystemTime::now(),
+            0,
+            0,
+        );
+        let recs = p.export_records();
+        let rec = recs.iter().find(|r| r.process == "backdoor").unwrap();
+        assert_eq!(rec.verdict, "undeclared");
+        assert_eq!(rec.matched_by, None);
+    }
+
+    /// Promotion must not widen a rule to an entire autonomous system: one
+    /// nameless flow to a hyperscaler would otherwise admit every host that
+    /// hyperscaler operates, for that process, permanently and invisibly.
+    #[test]
+    fn promotion_never_widens_to_an_autonomous_system() {
+        let mut p = EgressProfiler::new();
+        let now = SystemTime::now();
+        p.record(
+            "app",
+            "35.190.46.17",
+            443,
+            None,
+            Some("Google LLC".into()),
+            now,
+        );
+
+        let rule = p.promote_one("app").unwrap();
+        assert!(
+            rule.allow_asn.is_empty(),
+            "promoted an ASN: {:?}",
+            rule.allow_asn
+        );
+        assert_eq!(rule.allow_ip, vec!["35.190.46.17".to_string()]);
+
+        // The narrower rule still admits the baseline it came from...
+        assert!(rule
+            .violation(None, Some("Google LLC"), "35.190.46.17", 443)
+            .is_none());
+        // ...but a different Google-hosted endpoint is now drift, where the
+        // ASN-wide rule would have rendered it a clean tick.
+        assert!(rule
+            .violation(
+                Some("evil.appspot.com"),
+                Some("Google LLC"),
+                "35.190.46.99",
+                443
+            )
+            .is_some());
+    }
+
+    /// `Unassigned` is the geo database's *failure* label, not an
+    /// organisation. Allowlisting it would admit every destination whose ASN
+    /// lookup failed — an allowlist that grows by not working.
+    #[test]
+    fn a_failed_asn_lookup_is_never_promoted_as_an_identity() {
+        for label in ["Unassigned", "unassigned", "  ", "Unknown"] {
+            assert!(!is_identifying_asn(label), "{label:?} is not an identity");
+        }
+        assert!(is_identifying_asn("Google LLC"));
+
+        // Even on the last-resort path — no name and no address — a failure
+        // label must not become a rule.
+        let mut p = EgressProfiler::new();
+        p.record_flow(
+            "app",
+            "",
+            443,
+            None,
+            Some("Unassigned".into()),
+            false,
+            SystemTime::now(),
+            0,
+            0,
+        );
+        let rule = p.promote_one("app").unwrap_or_default();
+        assert!(rule.allow_asn.is_empty());
     }
 
     #[test]

--- a/src/collectors/egress.rs
+++ b/src/collectors/egress.rs
@@ -13,7 +13,7 @@
 //! ClientHello, so meaningful profiles form on the vast majority of traffic
 //! with no decryption and no keylog.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -36,6 +36,9 @@ pub(crate) const MAX_PROCESSES: usize = 256;
 const COMM_TRUNCATE_LEN: usize = 16;
 #[cfg(not(target_os = "macos"))]
 const COMM_TRUNCATE_LEN: usize = 15;
+/// Samples kept per destination for the inline activity sparkline — one
+/// per connection tick, so roughly the last minute at the 1 s default.
+pub(crate) const ACTIVITY_SAMPLES: usize = 40;
 /// Cap on distinct destinations tracked per process.
 const MAX_DESTS_PER_PROCESS: usize = 128;
 /// Re-warn at most this often for the same (process, destination, port)
@@ -49,7 +52,7 @@ const PERSIST_INTERVAL_SECS: u64 = 60;
 /// Schema tag stamped on the NDJSON export's `_meta` line. Bump the minor
 /// when adding fields (additive/back-compatible), the major on a breaking
 /// change — the managed ingest keys off this.
-pub const EGRESS_EXPORT_SCHEMA: &str = "netwatch.egress.v1";
+pub const EGRESS_EXPORT_SCHEMA: &str = "netwatch.egress.v1.1";
 
 /// One observed destination for a process.
 #[derive(Clone, Debug)]
@@ -76,7 +79,25 @@ pub struct EgressDest {
     pub first_seen: SystemTime,
     pub last_seen: SystemTime,
     /// Number of observations (connection-refresh ticks this dest appeared).
+    ///
+    /// Because `observe` runs once per ~1 s connection tick, this is really a
+    /// *dwell time in ticks*, not an event count — a single long-lived
+    /// connection accrues one per second it stays open. The UI renders it as
+    /// a duration for exactly that reason; don't relabel it "hits".
     pub count: u64,
+    /// Bytes attributed to this destination, accumulated from the per-tick
+    /// rates on the connection table (`rate × elapsed`). Approximate by
+    /// construction — the rates are themselves per-tick averages — and only
+    /// populated when packet capture is running, since that is what produces
+    /// the rates. Zero with no capture, which the UI shows as `—` rather
+    /// than a misleading 0 B.
+    pub bytes_out: u64,
+    pub bytes_in: u64,
+    /// Recent per-tick outbound bytes, newest last, for the inline
+    /// sparkline. Bounded to `ACTIVITY_SAMPLES`. Deliberately not persisted
+    /// — it is a live-session signal, and restoring one would be a lie
+    /// about what is happening now.
+    pub activity: VecDeque<u64>,
 }
 
 /// Identity of a destination within a process profile: the most specific
@@ -91,6 +112,56 @@ pub struct EgressDest {
 /// the Egress table fall back to it to repair rows whose `last_ip` is blank.
 /// Don't "simplify" it away.
 type DestKey = (String, u16);
+
+/// How a destination stands against the declared policy.
+///
+/// The distinction that matters is `Sni`/`Ip` versus `Asn`. A hostname or
+/// address match is a statement about *one endpoint*; an autonomous-system
+/// match admits everything that AS operates, which for a hyperscaler is
+/// effectively unbounded. Collapsing both into a single "ok" is what let a
+/// promoted rule quietly allow all of Google Cloud, so they are separate
+/// states and render differently.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    /// Matched a declared hostname — precise.
+    Sni,
+    /// Matched a declared IP — precise.
+    Ip,
+    /// Matched only by autonomous system — broad. Carries the org so the UI
+    /// can name what was actually admitted.
+    Asn(String),
+    /// Encrypted ClientHello: the real name is hidden by design, so this is
+    /// "cannot judge", not "bad".
+    Ech,
+    /// Outside the allowlist.
+    Drift,
+    /// The process has no rule, so nothing was checked. Distinct from
+    /// `NoPolicy` — here the operator has a policy and simply never declared
+    /// this program.
+    NoRule,
+    /// No policy loaded at all; observe-only.
+    NoPolicy,
+}
+
+impl Verdict {
+    /// Short glyph + label for the table's verdict column.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Verdict::Sni => "\u{2713} sni",
+            Verdict::Ip => "\u{2713} ip",
+            Verdict::Asn(_) => "~ asn",
+            Verdict::Ech => "? ech",
+            Verdict::Drift => "\u{2717} drift",
+            Verdict::NoRule => "\u{2014} no rule",
+            Verdict::NoPolicy => "\u{2014}",
+        }
+    }
+    /// True for states the operator should look at: broad matches and
+    /// outright drift. Drives colour and the header tally.
+    pub fn is_notable(&self) -> bool {
+        matches!(self, Verdict::Asn(_) | Verdict::Drift | Verdict::NoRule)
+    }
+}
 
 /// Per-process egress profile: the set of distinct destinations observed.
 #[derive(Clone, Debug)]
@@ -123,6 +194,18 @@ pub struct EgressRecord {
     /// Policy verdict at export time: `ok` | `drift` | `unreadable` (ECH,
     /// name hidden) | `unchecked` (no rule for this process).
     pub verdict: String,
+    /// Which dimension admitted an `ok` verdict — `sni` | `ip` | `asn`.
+    /// `None` for anything not admitted.
+    ///
+    /// Additive in schema v1.1. This is the breadth signal: `asn` means the
+    /// rule admitted an entire autonomous system, not one endpoint, so a
+    /// consumer can distinguish a precise allowlist from a rule that lets
+    /// through everything a hyperscaler operates.
+    pub matched_by: Option<String>,
+    /// Bytes attributed to this destination. Approximate (derived from
+    /// per-tick rates) and zero when packet capture isn't running.
+    pub bytes_out: u64,
+    pub bytes_in: u64,
 }
 
 /// A flow that violated a declared egress rule. Surfaced as a warning —
@@ -166,6 +249,8 @@ pub struct EgressProfiler {
     /// Retained recent violations for the on-screen warnings panel (bounded
     /// ring). Distinct from `pending`, which the caller drains each tick.
     recent: std::collections::VecDeque<RecentViolation>,
+    /// When `observe` last ran, so byte deltas can be derived from rates.
+    last_observe: Option<Instant>,
     /// Cumulative violation count per process (post-cooldown, so it tracks
     /// the alert stream). Bounded: only processes with a declared rule can
     /// violate. Feeds `netwatch_policy_violations_total` on /metrics.
@@ -183,6 +268,7 @@ impl Default for EgressProfiler {
             cooldown: Duration::from_secs(VIOLATION_COOLDOWN_SECS),
             pending: Vec::new(),
             recent: std::collections::VecDeque::new(),
+            last_observe: None,
             violation_totals: HashMap::new(),
             last_persist: None,
         }
@@ -221,6 +307,15 @@ impl EgressProfiler {
     pub fn observe(&mut self, connections: &[Connection], geo: &GeoCache) {
         let now = Instant::now();
         let wall = SystemTime::now();
+        // Seconds since the previous observe, used to turn the connection
+        // table's per-second rates into a byte delta for this tick. Clamped:
+        // a long stall (laptop sleep, a slow lsof) must not credit a
+        // destination with minutes of traffic it may not have sent.
+        let elapsed = self
+            .last_observe
+            .map(|t| now.duration_since(t).as_secs_f64().clamp(0.0, 5.0))
+            .unwrap_or(0.0);
+        self.last_observe = Some(now);
         for conn in connections {
             let Some(process) = conn.process_name.as_deref() else {
                 continue;
@@ -245,7 +340,22 @@ impl EgressProfiler {
             let sni = dest_hostname(&conn.app_protocol);
             let ech = flow_ech(&conn.app_protocol);
             let asn_org = geo.lookup(&ip).map(|g| g.org).filter(|o| !o.is_empty());
-            self.record_flow(process, &ip, port, sni.clone(), asn_org.clone(), ech, wall);
+            // Rates are present only while packet capture is running, so
+            // without it these stay zero and the UI shows "—" rather than a
+            // confident 0 B.
+            let out = (conn.tx_rate.unwrap_or(0.0) * elapsed).max(0.0) as u64;
+            let inb = (conn.rx_rate.unwrap_or(0.0) * elapsed).max(0.0) as u64;
+            self.record_flow(
+                process,
+                &ip,
+                port,
+                sni.clone(),
+                asn_org.clone(),
+                ech,
+                wall,
+                out,
+                inb,
+            );
             self.check_policy(process, &ip, port, &sni, &asn_org, ech, now);
         }
         self.evict_processes_if_needed();
@@ -352,23 +462,71 @@ impl EgressProfiler {
     /// no policy is loaded or the process has no rule (nothing to check),
     /// `Some(true)` when allowed, `Some(false)` when it drifts.
     pub fn dest_allowed(&self, process: &str, dest: &EgressDest) -> Option<bool> {
-        let policy = self.policy.as_ref()?;
+        match self.verdict(process, dest) {
+            Verdict::NoPolicy | Verdict::NoRule => None,
+            // ECH is a policy *miss* whose cause is an encrypted name. It
+            // stays `false` here so the export keeps reporting it as
+            // "unreadable"; only the presentation differs from real drift.
+            Verdict::Drift | Verdict::Ech => Some(false),
+            _ => Some(true),
+        }
+    }
+
+    /// Full verdict for a destination, naming *why* it passed.
+    ///
+    /// `dest_allowed` flattens this to a bool for callers that only need
+    /// pass/fail; the UI wants the reason, because "matched a hostname" and
+    /// "matched an entire autonomous system" are very different assurances.
+    pub fn verdict(&self, process: &str, dest: &EgressDest) -> Verdict {
+        let Some(policy) = self.policy.as_ref() else {
+            return Verdict::NoPolicy;
+        };
         // Same both-spellings lookup as `check_policy`, so the table verdict
         // and the warnings panel can never disagree about a truncated name.
         let canonical = self.canonical_process(process);
-        let rule = policy
+        let Some(rule) = policy
             .process
             .get(process)
-            .or_else(|| policy.process.get(canonical.as_str()))?;
-        Some(
-            rule.violation(
+            .or_else(|| policy.process.get(canonical.as_str()))
+        else {
+            return Verdict::NoRule;
+        };
+        if rule
+            .violation(
                 dest.sni.as_deref(),
                 dest.asn_org.as_deref(),
                 &dest.last_ip,
                 dest.port,
             )
-            .is_none(),
-        )
+            .is_some()
+        {
+            // An ECH flow's inner name is encrypted, so a miss is "can't
+            // read it", not "shouldn't be there".
+            return if dest.ech && dest.sni.is_none() {
+                Verdict::Ech
+            } else {
+                Verdict::Drift
+            };
+        }
+        // Admitted — report the most precise dimension that did it, in the
+        // same order `violation` checks them.
+        if dest
+            .sni
+            .as_deref()
+            .is_some_and(|h| rule.allow_sni.iter().any(|p| sni_matches(p, h)))
+        {
+            return Verdict::Sni;
+        }
+        if rule.allow_ip.iter().any(|x| x == &dest.last_ip) {
+            return Verdict::Ip;
+        }
+        if let Some(org) = dest.asn_org.as_deref() {
+            if rule.allow_asn.iter().any(|x| x.eq_ignore_ascii_case(org)) {
+                return Verdict::Asn(org.to_string());
+            }
+        }
+        // Admitted because the rule declares no name restriction at all.
+        Verdict::Sni
     }
 
     /// Drain the violations detected since the last call.
@@ -417,7 +575,7 @@ impl EgressProfiler {
         asn_org: Option<String>,
         now: SystemTime,
     ) {
-        self.record_flow(process, ip, port, sni, asn_org, false, now);
+        self.record_flow(process, ip, port, sni, asn_org, false, now, 0, 0);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -430,12 +588,25 @@ impl EgressProfiler {
         asn_org: Option<String>,
         ech: bool,
         now: SystemTime,
+        bytes_out: u64,
+        bytes_in: u64,
     ) {
         let label = sni
             .clone()
             .or_else(|| asn_org.clone())
             .unwrap_or_else(|| ip.to_string());
-        self.upsert(process, (label, port), sni, asn_org, port, ip, ech, now);
+        self.upsert(
+            process,
+            (label, port),
+            sni,
+            asn_org,
+            port,
+            ip,
+            ech,
+            now,
+            bytes_out,
+            bytes_in,
+        );
     }
 
     /// Resolve the profile key for an observed process name, folding a
@@ -554,6 +725,8 @@ impl EgressProfiler {
         ip: &str,
         ech: bool,
         now: SystemTime,
+        bytes_out: u64,
+        bytes_in: u64,
     ) {
         // Fold kernel-truncated and untruncated spellings of the same program
         // onto one key, in whichever order they arrive.
@@ -580,6 +753,12 @@ impl EgressProfiler {
             // — that turned named rows into blank ones on disk.
             if !ip.is_empty() {
                 dest.last_ip = ip.to_string();
+            }
+            dest.bytes_out = dest.bytes_out.saturating_add(bytes_out);
+            dest.bytes_in = dest.bytes_in.saturating_add(bytes_in);
+            dest.activity.push_back(bytes_out);
+            while dest.activity.len() > ACTIVITY_SAMPLES {
+                dest.activity.pop_front();
             }
             // Backfill a name/ASN that wasn't resolved on first sight (SNI
             // appears once the ClientHello is parsed; ASN once geo resolves).
@@ -613,6 +792,9 @@ impl EgressProfiler {
                 first_seen: now,
                 last_seen: now,
                 count: 1,
+                bytes_out,
+                bytes_in,
+                activity: VecDeque::from(vec![bytes_out]),
             },
         );
     }
@@ -654,6 +836,17 @@ impl EgressProfiler {
         self.profiles.values().map(|p| p.dests.len()).sum()
     }
 
+    /// Borrowed view of the profiles, sorted by process name.
+    ///
+    /// `snapshot` clones every profile, which the Egress tab used to do once
+    /// per frame; the tree view borrows instead so rendering allocates
+    /// nothing beyond the row list.
+    pub fn profiles_ref(&self) -> Vec<&EgressProfile> {
+        let mut out: Vec<&EgressProfile> = self.profiles.values().collect();
+        out.sort_by(|a, b| a.process.cmp(&b.process));
+        out
+    }
+
     /// Snapshot of all profiles, sorted by process name. Each profile's
     /// destinations can be sorted by the caller; the map is returned as-is.
     pub fn snapshot(&self) -> Vec<EgressProfile> {
@@ -675,13 +868,20 @@ impl EgressProfiler {
         let mut out = Vec::new();
         for profile in self.snapshot() {
             for dest in profile.dests.values() {
-                let verdict = match self.dest_allowed(&profile.process, dest) {
-                    Some(true) => "ok",
-                    Some(false) if dest.ech && dest.sni.is_none() => "unreadable",
-                    Some(false) => "drift",
-                    None => "unchecked",
+                let v = self.verdict(&profile.process, dest);
+                let verdict = match &v {
+                    Verdict::Ech => "unreadable",
+                    Verdict::Drift => "drift",
+                    Verdict::NoRule | Verdict::NoPolicy => "unchecked",
+                    _ => "ok",
                 }
                 .to_string();
+                let matched_by = match &v {
+                    Verdict::Sni => Some("sni".to_string()),
+                    Verdict::Ip => Some("ip".to_string()),
+                    Verdict::Asn(_) => Some("asn".to_string()),
+                    _ => None,
+                };
                 out.push(EgressRecord {
                     process: profile.process.clone(),
                     sni: dest.sni.clone(),
@@ -694,6 +894,9 @@ impl EgressProfiler {
                     last_seen: unix_secs(dest.last_seen),
                     count: dest.count,
                     verdict,
+                    matched_by,
+                    bytes_out: dest.bytes_out,
+                    bytes_in: dest.bytes_in,
                 });
             }
         }
@@ -776,6 +979,8 @@ impl EgressProfiler {
                             first_seen: unix_secs(d.first_seen),
                             last_seen: unix_secs(d.last_seen),
                             count: d.count,
+                            bytes_out: d.bytes_out,
+                            bytes_in: d.bytes_in,
                         })
                         .collect(),
                 })
@@ -858,6 +1063,11 @@ impl EgressProfiler {
                         first_seen: from_unix_secs(dest.first_seen),
                         last_seen,
                         count: dest.count,
+                        bytes_out: dest.bytes_out,
+                        bytes_in: dest.bytes_in,
+                        // Activity is a live signal; a restored spark would
+                        // claim traffic that isn't happening.
+                        activity: VecDeque::new(),
                     });
             }
         }
@@ -964,6 +1174,10 @@ struct PersistedDest {
     first_seen: u64,
     last_seen: u64,
     count: u64,
+    #[serde(default)]
+    bytes_out: u64,
+    #[serde(default)]
+    bytes_in: u64,
 }
 
 /// Default learned-baseline location: `<state_dir>/netwatch/egress-profiles.json`
@@ -1874,6 +2088,8 @@ mod tests {
             Some("Cloudflare".into()),
             true,
             now,
+            0,
+            0,
         );
         p.record_flow(
             "chrome",
@@ -1883,6 +2099,8 @@ mod tests {
             Some("Cloudflare".into()),
             false,
             now,
+            0,
+            0,
         );
         let snap = p.snapshot();
         let dest = snap[0].dests.get(&("Cloudflare".to_string(), 443)).unwrap();
@@ -2007,6 +2225,8 @@ mod tests {
             Some("Cloudflare".into()),
             true,
             SystemTime::now(),
+            0,
+            0,
         );
         let mut policy = EgressPolicy::default();
         policy.process.insert(
@@ -2320,6 +2540,9 @@ mod blank_and_split_regressions {
             first_seen: SystemTime::now(),
             last_seen: SystemTime::now(),
             count: 1,
+            bytes_out: 0,
+            bytes_in: 0,
+            activity: VecDeque::new(),
         }
     }
 
@@ -2535,5 +2758,170 @@ mod blank_and_split_regressions {
             Some(true),
             "declared destination warned as drift under the truncated name"
         );
+    }
+}
+
+/// The verdict vocabulary: `✓ sni` and `~ asn` are both "admitted", but only
+/// one of them is a statement about a single endpoint. Collapsing them is
+/// what let a promoted rule quietly allow an entire hyperscaler.
+#[cfg(test)]
+mod verdict_tests {
+    use super::*;
+
+    fn rule(sni: &[&str], asn: &[&str], ip: &[&str], ports: &[u16]) -> ProcessRule {
+        ProcessRule {
+            allow_sni: sni.iter().map(|s| s.to_string()).collect(),
+            allow_asn: asn.iter().map(|s| s.to_string()).collect(),
+            allow_ip: ip.iter().map(|s| s.to_string()).collect(),
+            allow_ports: ports.to_vec(),
+        }
+    }
+
+    fn profiler(r: ProcessRule) -> EgressProfiler {
+        let mut p = EgressProfiler::new();
+        let mut policy = EgressPolicy::default();
+        policy.process.insert("app".into(), r);
+        p.set_policy(Some(policy));
+        p
+    }
+
+    fn dest(sni: Option<&str>, asn: Option<&str>, ip: &str, ech: bool) -> EgressDest {
+        EgressDest {
+            sni: sni.map(str::to_string),
+            asn_org: asn.map(str::to_string),
+            port: 443,
+            last_ip: ip.to_string(),
+            ech,
+            first_seen: SystemTime::now(),
+            last_seen: SystemTime::now(),
+            count: 1,
+            bytes_out: 0,
+            bytes_in: 0,
+            activity: VecDeque::new(),
+        }
+    }
+
+    #[test]
+    fn exact_hostname_is_reported_as_precise() {
+        let p = profiler(rule(&["api.example.com"], &[], &[], &[]));
+        assert_eq!(
+            p.verdict(
+                "app",
+                &dest(Some("api.example.com"), None, "1.2.3.4", false)
+            ),
+            Verdict::Sni
+        );
+    }
+
+    /// The finding this whole vocabulary exists for: admitted, but by an
+    /// autonomous system rather than a name. Must not read as `Sni`.
+    #[test]
+    fn asn_match_is_distinguished_from_a_name_match() {
+        let p = profiler(rule(&["api.example.com"], &["Google LLC"], &[], &[]));
+        let v = p.verdict("app", &dest(None, Some("Google LLC"), "1.2.3.4", false));
+        assert_eq!(v, Verdict::Asn("Google LLC".into()));
+        assert!(v.is_notable(), "an ASN-wide match must be flagged");
+        assert_ne!(v, Verdict::Sni);
+    }
+
+    /// A destination with a readable name that isn't declared, admitted only
+    /// because its ASN is — the silent over-admission. It must surface as
+    /// `Asn`, not a clean tick.
+    #[test]
+    fn undeclared_hostname_admitted_by_asn_is_flagged_not_clean() {
+        let p = profiler(rule(&["api.example.com"], &["Google LLC"], &[], &[]));
+        let v = p.verdict(
+            "app",
+            &dest(
+                Some("evil.appspot.com"),
+                Some("Google LLC"),
+                "1.2.3.4",
+                false,
+            ),
+        );
+        assert_eq!(v, Verdict::Asn("Google LLC".into()));
+        assert!(v.is_notable());
+    }
+
+    #[test]
+    fn declared_ip_is_precise() {
+        let p = profiler(rule(&[], &[], &["1.2.3.4"], &[]));
+        assert_eq!(
+            p.verdict("app", &dest(None, None, "1.2.3.4", false)),
+            Verdict::Ip
+        );
+    }
+
+    #[test]
+    fn outside_the_allowlist_is_drift() {
+        let p = profiler(rule(&["api.example.com"], &[], &[], &[]));
+        assert_eq!(
+            p.verdict(
+                "app",
+                &dest(Some("evil.example.net"), None, "9.9.9.9", false)
+            ),
+            Verdict::Drift
+        );
+    }
+
+    /// ECH hides the real name, so a miss is "cannot judge" — never drift.
+    #[test]
+    fn ech_miss_is_unreadable_not_drift() {
+        let p = profiler(rule(&["api.example.com"], &[], &[], &[]));
+        assert_eq!(
+            p.verdict("app", &dest(None, None, "9.9.9.9", true)),
+            Verdict::Ech
+        );
+    }
+
+    /// The critical coverage gap, made explicit: a process with no rule is
+    /// never checked, and that must be a distinct visible state rather than
+    /// looking like approval.
+    #[test]
+    fn undeclared_process_is_unchecked_not_approved() {
+        let p = profiler(rule(&["api.example.com"], &[], &[], &[]));
+        let v = p.verdict("other", &dest(Some("anything.com"), None, "9.9.9.9", false));
+        assert_eq!(v, Verdict::NoRule);
+        assert!(v.is_notable(), "unchecked must be visible");
+        assert_ne!(v, Verdict::Sni);
+    }
+
+    #[test]
+    fn no_policy_is_its_own_state() {
+        let p = EgressProfiler::new();
+        assert_eq!(
+            p.verdict("app", &dest(Some("x.com"), None, "1.2.3.4", false)),
+            Verdict::NoPolicy
+        );
+    }
+
+    /// A port outside the allowlist is drift regardless of the name.
+    #[test]
+    fn port_outside_the_allowlist_is_drift() {
+        let p = profiler(rule(&["api.example.com"], &[], &[], &[8443]));
+        assert_eq!(
+            p.verdict(
+                "app",
+                &dest(Some("api.example.com"), None, "1.2.3.4", false)
+            ),
+            Verdict::Drift
+        );
+    }
+
+    #[test]
+    fn bytes_accumulate_and_never_downgrade() {
+        let mut p = EgressProfiler::new();
+        let t = SystemTime::now();
+        p.record_flow("app", "1.2.3.4", 443, sni("a.com"), None, false, t, 100, 10);
+        p.record_flow("app", "1.2.3.4", 443, sni("a.com"), None, false, t, 50, 5);
+        let snap = p.snapshot();
+        let d = snap[0].dests.values().next().unwrap();
+        assert_eq!(d.bytes_out, 150);
+        assert_eq!(d.bytes_in, 15);
+        assert_eq!(d.activity.len(), 2, "one activity sample per observation");
+    }
+
+    fn sni(h: &str) -> Option<String> {
+        Some(h.to_string())
     }
 }

--- a/src/collectors/egress.rs
+++ b/src/collectors/egress.rs
@@ -1523,12 +1523,99 @@ fn union_ports(existing: Option<&toml_edit::Item>, key: &str, add: &[u16]) -> Ve
     set.into_iter().collect()
 }
 
+/// Delete the named processes' rules from the policy file, preserving
+/// everything else. The counterpart to `merge_rules_into_policy_file`, which
+/// only ever grows an allowlist.
+///
+/// Returns the names actually removed — a name with no rule is not an error,
+/// it is simply nothing to do, and the caller says so rather than claiming a
+/// removal that didn't happen.
+///
+/// Removing a rule is the one destructive operation in the linter: it can
+/// discard hand-written entries the baseline cannot regenerate. So it refuses
+/// an unparseable file for the same reason promotion does, writes owner-only,
+/// and the caller is expected to confirm first.
+///
+/// A comment sitting immediately above a rule goes with it — such a comment
+/// documents that rule, and leaving it behind would orphan a note about
+/// something no longer in the file. The one exception is the file's own
+/// leading comment block, which `toml_edit` happens to store as the first
+/// table's prefix: removing the first (or only) rule would otherwise delete
+/// the header explaining `strict` and the promotion semantics, leaving a file
+/// with no hint of how to get it back. That block is restored explicitly.
+pub fn remove_rules_from_policy_file(
+    names: &[String],
+    path: &Path,
+) -> std::io::Result<Vec<String>> {
+    let existing = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        // Nothing declared anywhere: removing is vacuously done. Creating the
+        // file here just to delete from it would be absurd.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    let mut doc: toml_edit::DocumentMut = existing.parse().map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("existing policy does not parse (fix it by hand first): {e}"),
+        )
+    })?;
+
+    let mut removed = Vec::new();
+    if let Some(tbl) = doc.get_mut("process").and_then(|p| p.as_table_mut()) {
+        for name in names {
+            if tbl.remove(name.as_str()).is_some() {
+                removed.push(name.clone());
+            }
+        }
+        // Leave `[process]` implicit so an emptied policy renders as the
+        // header and nothing else, rather than a stray bare table.
+        tbl.set_implicit(true);
+    }
+    if removed.is_empty() {
+        return Ok(removed);
+    }
+    let mut body = doc.to_string();
+    let head = leading_comment_block(&existing);
+    if !head.is_empty() && !body.starts_with(&head) {
+        body.insert_str(0, &head);
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    write_owner_only(path, body.as_bytes())?;
+    Ok(removed)
+}
+
+/// The run of comment and blank lines at the very top of a policy file — its
+/// header. Returned with the trailing newline so it can be re-prepended
+/// verbatim.
+fn leading_comment_block(src: &str) -> String {
+    let mut out = String::new();
+    for line in src.lines() {
+        let t = line.trim_start();
+        if t.starts_with('#') || t.is_empty() {
+            out.push_str(line);
+            out.push('\n');
+        } else {
+            break;
+        }
+    }
+    // A file that is *only* comments has no rules to remove, so preserving
+    // "everything" would be a no-op anyway; more usefully, this stops a
+    // comment-only file from being duplicated onto itself.
+    if out.len() == src.len() {
+        return String::new();
+    }
+    out
+}
+
 /// Upsert `rules` into the policy file, preserving everything else — hand
 /// edits, comments, and rules for processes not being promoted. Promotion
 /// is additive per process: it unions the observed entries with those already
-/// declared (it never shrinks or deletes an allowlist). Refuses (rather than
-/// clobbers) a file that no longer parses, so a broken hand edit is never
-/// silently thrown away.
+/// declared (it never shrinks or deletes an allowlist). Removal is
+/// `remove_rules_from_policy_file`. Refuses (rather than clobbers) a file that
+/// no longer parses, so a broken hand edit is never silently thrown away.
 pub fn merge_rules_into_policy_file(
     rules: &[(String, ProcessRule)],
     path: &Path,
@@ -2126,6 +2213,185 @@ mod tests {
         assert!(body.contains("# my hand-written note"));
         assert!(body.contains("gstatic"));
         assert!(body.contains("[process.ssh]"));
+    }
+
+    /// Removal is surgical: the named rule goes, everything a human put in
+    /// the file stays.
+    #[test]
+    fn remove_deletes_only_the_named_rule() {
+        let path = scratch("remove.toml");
+        std::fs::write(
+            &path,
+            "# my hand-written note\n\n\
+             [process.ssh]\nallow_ports = [22] # keep tight\n\n\
+             [process.chrome]\nallow_sni = [\"*.google.com\"]\nallow_ports = [443]\n",
+        )
+        .unwrap();
+
+        let removed = remove_rules_from_policy_file(&["chrome".to_string()], &path).unwrap();
+        assert_eq!(removed, vec!["chrome".to_string()]);
+
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(!body.contains("chrome"), "the rule is gone: {body}");
+        assert!(body.contains("# my hand-written note"), "comments survive");
+        assert!(body.contains("# keep tight"), "inline comments survive");
+        let parsed: EgressPolicy = toml::from_str(&body).unwrap();
+        assert!(!parsed.process.contains_key("chrome"));
+        assert_eq!(parsed.process.get("ssh").unwrap().allow_ports, vec![22]);
+    }
+
+    /// Removing the last (or first) rule must not take the file's header with
+    /// it. `toml_edit` stores the leading comment block as the first table's
+    /// prefix, so a naive removal emptied the file completely — leaving the
+    /// user with no record of what `strict` does or how to promote again.
+    #[test]
+    fn removing_the_only_rule_keeps_the_file_header() {
+        let path = scratch("remove-header.toml");
+        let rules = vec![("chrome".to_string(), ProcessRule::default())];
+        merge_rules_into_policy_file(&rules, &path).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+        assert!(before.contains("observe → promote → warn"));
+
+        remove_rules_from_policy_file(&["chrome".to_string()], &path).unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after.contains("observe → promote → warn"),
+            "the generated header must survive: {after:?}"
+        );
+        assert!(
+            after.contains("strict = true"),
+            "including the part documenting strict mode: {after:?}"
+        );
+        assert!(!after.contains("[process.chrome]"), "the rule is gone");
+        // Still a valid, loadable policy — not a pile of comments plus junk.
+        let parsed: EgressPolicy = toml::from_str(&after).unwrap();
+        assert!(parsed.process.is_empty());
+        // And promoting again reproduces a normal file, not a doubled header.
+        merge_rules_into_policy_file(&rules, &path).unwrap();
+        let again = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            again.matches("observe → promote → warn").count(),
+            1,
+            "header must not be duplicated: {again:?}"
+        );
+    }
+
+    /// Removing something that was never declared is not an error — but the
+    /// caller must be able to tell, so it doesn't report a removal that
+    /// didn't happen. The file is left untouched.
+    #[test]
+    fn removing_an_undeclared_process_reports_nothing_removed() {
+        let path = scratch("remove-absent.toml");
+        let original = "[process.ssh]\nallow_ports = [22]\n";
+        std::fs::write(&path, original).unwrap();
+
+        let removed = remove_rules_from_policy_file(&["nothere".to_string()], &path).unwrap();
+        assert!(removed.is_empty());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+
+        // No file at all is likewise vacuously done, and must not create one.
+        let missing = path.parent().unwrap().join("does-not-exist.toml");
+        assert!(remove_rules_from_policy_file(&["x".to_string()], &missing)
+            .unwrap()
+            .is_empty());
+        assert!(!missing.exists(), "removal must not create a policy file");
+    }
+
+    /// Same guard as promotion: a file that no longer parses is refused, not
+    /// rewritten. Losing a broken hand edit is worse than failing loudly.
+    #[test]
+    fn remove_refuses_to_clobber_unparseable_policy() {
+        let path = scratch("remove-broken.toml");
+        std::fs::write(&path, "[process.ssh\nallow_ports = [22]").unwrap();
+        let err = remove_rules_from_policy_file(&["ssh".to_string()], &path).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(std::fs::read_to_string(&path)
+            .unwrap()
+            .starts_with("[process.ssh\n"));
+    }
+
+    /// Remove-then-re-add is the round trip a user will actually perform, and
+    /// the rewritten file must still be loadable — including its permissions,
+    /// since `load_policy_file` refuses a group/world-writable policy.
+    #[test]
+    fn removed_process_stops_being_checked_and_can_be_re_added() {
+        let path = scratch("remove-roundtrip.toml");
+        let rules = vec![(
+            "chrome".to_string(),
+            ProcessRule {
+                allow_sni: vec!["api.example.com".into()],
+                allow_asn: vec![],
+                allow_ip: vec![],
+                allow_ports: vec![443],
+            },
+        )];
+        merge_rules_into_policy_file(&rules, &path).unwrap();
+        assert!(load_policy_file(&path)
+            .unwrap()
+            .process
+            .contains_key("chrome"));
+
+        remove_rules_from_policy_file(&["chrome".to_string()], &path).unwrap();
+        let policy = load_policy_file(&path).expect("policy still loads after removal");
+        assert!(policy.process.is_empty());
+
+        // The destination that was declared now reads as unchecked rather
+        // than allowed — coverage was withdrawn, not granted.
+        let mut p = EgressProfiler::new();
+        p.set_policy(Some(policy));
+        let d = EgressDest {
+            sni: Some("api.example.com".into()),
+            asn_org: None,
+            port: 443,
+            last_ip: "1.2.3.4".into(),
+            ech: false,
+            first_seen: SystemTime::now(),
+            last_seen: SystemTime::now(),
+            count: 1,
+            bytes_out: 0,
+            bytes_in: 0,
+            activity: VecDeque::new(),
+        };
+        assert_eq!(p.verdict("chrome", &d), Verdict::NoRule);
+
+        // And it can be put back.
+        merge_rules_into_policy_file(&rules, &path).unwrap();
+        p.set_policy(load_policy_file(&path));
+        assert_eq!(p.verdict("chrome", &d), Verdict::Sni);
+    }
+
+    /// Under a policy declaring itself complete, removing a rule does not make
+    /// a process go quiet — it makes it a finding.
+    #[test]
+    fn removal_under_strict_surfaces_the_process_as_undeclared() {
+        let path = scratch("remove-strict.toml");
+        std::fs::write(
+            &path,
+            "strict = true\n\n[process.chrome]\nallow_sni = [\"api.example.com\"]\n",
+        )
+        .unwrap();
+        write_owner_only(&path, std::fs::read(&path).unwrap().as_slice()).unwrap();
+
+        remove_rules_from_policy_file(&["chrome".to_string()], &path).unwrap();
+        let policy = load_policy_file(&path).expect("loads after removal");
+        assert!(policy.strict, "the strict flag is not collateral damage");
+
+        let mut p = EgressProfiler::new();
+        p.set_policy(Some(policy));
+        let d = EgressDest {
+            sni: Some("api.example.com".into()),
+            asn_org: None,
+            port: 443,
+            last_ip: "1.2.3.4".into(),
+            ech: false,
+            first_seen: SystemTime::now(),
+            last_seen: SystemTime::now(),
+            count: 1,
+            bytes_out: 0,
+            bytes_in: 0,
+            activity: VecDeque::new(),
+        };
+        assert_eq!(p.verdict("chrome", &d), Verdict::Undeclared);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,17 @@ pub struct NetwatchConfig {
     /// 0 warns on every connection refresh. Default 300 (5 minutes).
     #[serde(default = "default_egress_cooldown")]
     pub egress_violation_cooldown_secs: u64,
+
+    /// Whether the grouped tables (Connections, Egress) open with every group
+    /// folded. Default true: a folded screen answers "what is on this machine"
+    /// in one glance, and expanding is one keystroke. Set false to open with
+    /// everything visible, which is closer to the old flat tables.
+    #[serde(default = "default_groups_collapsed")]
+    pub groups_start_collapsed: bool,
+}
+
+fn default_groups_collapsed() -> bool {
+    true
 }
 
 fn default_sandbox() -> String {
@@ -139,6 +150,7 @@ impl Default for NetwatchConfig {
             sandbox: default_sandbox(),
             tls_keylog_path: String::new(),
             egress_violation_cooldown_secs: default_egress_cooldown(),
+            groups_start_collapsed: default_groups_collapsed(),
         }
     }
 }
@@ -305,6 +317,7 @@ show_geo = false
             sandbox: "strict".into(),
             tls_keylog_path: "/tmp/sslkeylog.txt".into(),
             egress_violation_cooldown_secs: 120,
+            groups_start_collapsed: false,
         };
         let serialized = toml::to_string_pretty(&cfg).unwrap();
         let deserialized: NetwatchConfig = toml::from_str(&serialized).unwrap();

--- a/src/state.rs
+++ b/src/state.rs
@@ -89,6 +89,41 @@ pub struct LiteState {
 /// Future tests can construct an `AppUiState` directly and exercise event
 /// handlers (filter parsing, settings cursor movement, status fade timers)
 /// without needing to spin up any collector threads.
+/// Ordering for the Egress tree. Volume first by default: on a screen whose
+/// job is "what left this machine", the biggest talker is the story.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum EgressSort {
+    #[default]
+    Volume,
+    Active,
+    Process,
+    LastSeen,
+    Risk,
+}
+
+impl EgressSort {
+    pub const ALL: &'static [EgressSort] = &[
+        EgressSort::Volume,
+        EgressSort::Active,
+        EgressSort::Process,
+        EgressSort::LastSeen,
+        EgressSort::Risk,
+    ];
+    pub fn label(self) -> &'static str {
+        match self {
+            EgressSort::Volume => "volume",
+            EgressSort::Active => "active",
+            EgressSort::Process => "process",
+            EgressSort::LastSeen => "last seen",
+            EgressSort::Risk => "risk",
+        }
+    }
+    pub fn next(self) -> EgressSort {
+        let i = EgressSort::ALL.iter().position(|x| *x == self).unwrap_or(0);
+        EgressSort::ALL[(i + 1) % EgressSort::ALL.len()]
+    }
+}
+
 pub struct AppUiState {
     pub current_tab: Tab,
     /// Full tabbed TUI vs the single-screen Lite view. Opt-in only.
@@ -117,6 +152,19 @@ pub struct AppUiState {
     pub connection_filter_input: bool,
     pub connection_filter_text: String,
     pub connection_filter_active: Option<String>,
+    pub egress_filter_input: bool,
+    pub egress_filter_text: String,
+    pub egress_filter_active: Option<String>,
+
+    // ── Egress-tab specifics ──
+    /// Processes whose destination rows are collapsed. Collapsed is the
+    /// exception, so an empty set means "everything expanded" and a fresh
+    /// session shows all the detail.
+    pub egress_collapsed: std::collections::HashSet<String>,
+    /// Column the Egress tree is ordered by.
+    pub egress_sort: EgressSort,
+    /// Whether the destination detail pane is open (`d`).
+    pub egress_detail: bool,
 
     // ── Packet-tab specifics ──
     pub packet_follow: bool,
@@ -182,6 +230,12 @@ impl AppUiState {
             connection_filter_input: false,
             connection_filter_text: String::new(),
             connection_filter_active: None,
+            egress_filter_input: false,
+            egress_filter_text: String::new(),
+            egress_filter_active: None,
+            egress_collapsed: std::collections::HashSet::new(),
+            egress_sort: EgressSort::default(),
+            egress_detail: false,
 
             packet_follow: cfg.packet_follow,
             packet_detail_expanded: false,

--- a/src/state.rs
+++ b/src/state.rs
@@ -165,6 +165,12 @@ pub struct AppUiState {
     pub egress_sort: EgressSort,
     /// Whether the destination detail pane is open (`d`).
     pub egress_detail: bool,
+    /// Groups whose connection rows are collapsed on the Connections tab.
+    /// Keyed by group value (process name or remote host), so the fold
+    /// survives re-sorting and the list churning between ticks. Collapsed is
+    /// the exception, so an empty set means everything expanded.
+    pub connection_collapsed: std::collections::HashSet<String>,
+
     /// Process whose rule removal is awaiting confirmation (`x`, then `y`).
     ///
     /// Removal is the only destructive action on this tab — it can discard
@@ -244,6 +250,7 @@ impl AppUiState {
             egress_collapsed: std::collections::HashSet::new(),
             egress_sort: EgressSort::default(),
             egress_detail: false,
+            connection_collapsed: std::collections::HashSet::new(),
             egress_pending_removal: None,
 
             packet_follow: cfg.packet_follow,

--- a/src/state.rs
+++ b/src/state.rs
@@ -165,6 +165,14 @@ pub struct AppUiState {
     pub egress_sort: EgressSort,
     /// Whether the destination detail pane is open (`d`).
     pub egress_detail: bool,
+    /// Process whose rule removal is awaiting confirmation (`x`, then `y`).
+    ///
+    /// Removal is the only destructive action on this tab — it can discard
+    /// hand-written allowlist entries that no amount of re-observation will
+    /// bring back, since promotion only ever regenerates what was *seen*. So
+    /// it asks, unlike promote, which is additive and therefore safe to fire
+    /// on a single keystroke.
+    pub egress_pending_removal: Option<String>,
 
     // ── Packet-tab specifics ──
     pub packet_follow: bool,
@@ -236,6 +244,7 @@ impl AppUiState {
             egress_collapsed: std::collections::HashSet::new(),
             egress_sort: EgressSort::default(),
             egress_detail: false,
+            egress_pending_removal: None,
 
             packet_follow: cfg.packet_follow,
             packet_detail_expanded: false,

--- a/src/state.rs
+++ b/src/state.rs
@@ -157,19 +157,19 @@ pub struct AppUiState {
     pub egress_filter_active: Option<String>,
 
     // ── Egress-tab specifics ──
-    /// Processes whose destination rows are collapsed. Collapsed is the
-    /// exception, so an empty set means "everything expanded" and a fresh
-    /// session shows all the detail.
-    pub egress_collapsed: std::collections::HashSet<String>,
+    /// Which processes' destination rows are folded. Carries a default plus
+    /// exceptions rather than a set of names, so a process first seen after
+    /// the user folded everything arrives folded too — see
+    /// [`crate::ui::tree::FoldState`].
+    pub egress_collapsed: crate::ui::tree::FoldState,
     /// Column the Egress tree is ordered by.
     pub egress_sort: EgressSort,
     /// Whether the destination detail pane is open (`d`).
     pub egress_detail: bool,
-    /// Groups whose connection rows are collapsed on the Connections tab.
-    /// Keyed by group value (process name or remote host), so the fold
-    /// survives re-sorting and the list churning between ticks. Collapsed is
-    /// the exception, so an empty set means everything expanded.
-    pub connection_collapsed: std::collections::HashSet<String>,
+    /// Which connection groups are folded. Keyed by group value (process
+    /// name or remote host), so the fold survives re-sorting and the list
+    /// churning between ticks.
+    pub connection_collapsed: crate::ui::tree::FoldState,
 
     /// Process whose rule removal is awaiting confirmation (`x`, then `y`).
     ///
@@ -247,10 +247,10 @@ impl AppUiState {
             egress_filter_input: false,
             egress_filter_text: String::new(),
             egress_filter_active: None,
-            egress_collapsed: std::collections::HashSet::new(),
+            egress_collapsed: crate::ui::tree::FoldState::new(cfg.groups_start_collapsed),
             egress_sort: EgressSort::default(),
             egress_detail: false,
-            connection_collapsed: std::collections::HashSet::new(),
+            connection_collapsed: crate::ui::tree::FoldState::new(cfg.groups_start_collapsed),
             egress_pending_removal: None,
 
             packet_follow: cfg.packet_follow,

--- a/src/ui/connections.rs
+++ b/src/ui/connections.rs
@@ -91,12 +91,7 @@ pub(crate) fn table_inner_area(area: Rect) -> Rect {
 /// Centered-on-selected window top, matching the renderer's auto-scroll
 /// behaviour. Pure function so both sides can compute the same value.
 pub(crate) fn compute_window_top(selected: usize, total: usize, visible_rows: usize) -> usize {
-    if selected < visible_rows {
-        return 0;
-    }
-    selected
-        .saturating_sub(visible_rows / 2)
-        .min(total.saturating_sub(visible_rows))
+    crate::ui::tree::window_top(selected, total, visible_rows)
 }
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
@@ -538,6 +533,227 @@ pub(crate) fn filtered_sorted_conns(app: &App) -> Vec<Connection> {
     conns
 }
 
+// ── Grouped tree ────────────────────────────────────────────────────────
+//
+// `group: process` and `group: remote` used to be sort orders wearing the
+// word "group": rows clustered, but the key was still restated on every one.
+// On a real machine that meant `claude` down eleven consecutive rows and the
+// process column so starved of width it rendered `Google Chrome…`. These are
+// now actual trees — one parent row carrying the rollup, children foldable
+// beneath — built on `ui::tree`, the same machinery as the Egress tab.
+//
+// `group: none` stays a flat list. It is the mode you pick precisely when you
+// want every connection as a peer, and a tree with one child per parent would
+// be strictly worse.
+
+/// Summary shown on a group's parent row.
+pub struct ConnRollup {
+    pub conns: usize,
+    /// Distinct PIDs (process grouping) or distinct processes (remote
+    /// grouping) — the count that says "this row is more than one thing".
+    pub facets: usize,
+    pub rx_rate: f64,
+    pub tx_rate: f64,
+    /// Best (lowest) handshake RTT across the group, if any was measured.
+    pub rtt_us: Option<f64>,
+    /// Dominant connection state, and how many of the group share it.
+    pub state: String,
+    pub state_count: usize,
+    /// True when any member carries retransmits — a rollup must not hide a
+    /// problem that would be visible on an expanded child row.
+    pub degraded: bool,
+    /// True when every member was attributed by the kernel (PKTAP / eBPF),
+    /// so the parent can carry the same `◉` the children would.
+    pub kernel_attributed: bool,
+}
+
+pub type ConnGroup = crate::ui::tree::Group<ConnRollup, Connection>;
+
+/// One line of the Connections table.
+pub enum ConnRow<'a> {
+    Parent {
+        group: &'a ConnGroup,
+        collapsed: bool,
+    },
+    Conn {
+        conn: &'a Connection,
+    },
+}
+
+/// The connection list in whatever shape the current group mode implies.
+///
+/// Owns its data so the borrowed row list can be derived from it repeatedly —
+/// the renderer, the mouse handler and the key handlers all need the same
+/// numbering, and recomputing it independently is how they drift apart.
+pub struct ConnView {
+    pub groups: Vec<ConnGroup>,
+    pub flat: Vec<Connection>,
+}
+
+/// The most common *named* state in a group, and how many share it.
+///
+/// Connectionless rows (UDP) carry an empty state, so counting them would
+/// make "" the winner and the cell would render as a bare `11/13` — a
+/// fraction of nothing. Only named states compete; a group with none at all
+/// says so with an em-dash.
+fn dominant_state(conns: &[Connection]) -> (String, usize) {
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for c in conns.iter().filter(|c| !c.state.is_empty()) {
+        *counts.entry(c.state.as_str()).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(a.0)))
+        .map(|(s, n)| (s.to_string(), n))
+        .unwrap_or_else(|| ("—".to_string(), conns.len()))
+}
+
+fn rollup(key_is_process: bool, conns: &[Connection]) -> ConnRollup {
+    let facets: std::collections::BTreeSet<String> = if key_is_process {
+        conns
+            .iter()
+            .filter_map(|c| c.pid.map(|p| p.to_string()))
+            .collect()
+    } else {
+        conns
+            .iter()
+            .map(|c| c.process_name.clone().unwrap_or_else(|| "—".into()))
+            .collect()
+    };
+    let (state, state_count) = dominant_state(conns);
+    ConnRollup {
+        conns: conns.len(),
+        facets: facets.len(),
+        rx_rate: conns.iter().filter_map(|c| c.rx_rate).sum(),
+        tx_rate: conns.iter().filter_map(|c| c.tx_rate).sum(),
+        rtt_us: conns
+            .iter()
+            .filter_map(|c| c.handshake_rtt_us)
+            .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)),
+        state,
+        state_count,
+        degraded: conns.iter().any(|c| c.retransmits > 0),
+        kernel_attributed: !conns.is_empty()
+            && conns.iter().all(|c| {
+                matches!(
+                    c.attribution,
+                    AttributionSource::Pktap | AttributionSource::Ebpf
+                )
+            }),
+    }
+}
+
+/// Build the current view: grouped into a tree, or flat under `group: none`.
+pub fn build_view(app: &App) -> ConnView {
+    let conns = filtered_sorted_conns(app);
+    let group_mode = app.ui.connection_group;
+    if matches!(group_mode, ConnectionGroup::None) {
+        return ConnView {
+            groups: Vec::new(),
+            flat: conns,
+        };
+    }
+    let key_is_process = matches!(group_mode, ConnectionGroup::Process);
+    let buckets = crate::ui::tree::group_by(conns, |c: &Connection| {
+        if key_is_process {
+            c.process_name.clone().unwrap_or_else(|| "—".into())
+        } else {
+            host_only(&c.remote_addr)
+        }
+    });
+    // `filtered_sorted_conns` already ordered by the group key then by rate,
+    // so first-seen bucket order is the order the user asked for; only the
+    // rollup-level ranking is left, and busiest-first is what a rate column
+    // is for.
+    let mut groups: Vec<ConnGroup> = buckets
+        .into_iter()
+        .map(|(key, children)| ConnGroup {
+            key,
+            rollup: rollup(key_is_process, &children),
+            children,
+        })
+        .collect();
+    groups.sort_by(|a, b| {
+        cmp_f64(
+            a.rollup.rx_rate + a.rollup.tx_rate,
+            b.rollup.rx_rate + b.rollup.tx_rate,
+        )
+        .reverse()
+        .then_with(|| cmp_case_insensitive(&a.key, &b.key))
+    });
+    ConnView {
+        groups,
+        flat: Vec::new(),
+    }
+}
+
+impl ConnView {
+    /// The visible rows, honouring fold state. Single source of truth for
+    /// "what is row N" — renderer and input handlers both go through it.
+    pub fn rows(&self, collapsed: &std::collections::HashSet<String>) -> Vec<ConnRow<'_>> {
+        if self.groups.is_empty() {
+            return self
+                .flat
+                .iter()
+                .map(|conn| ConnRow::Conn { conn })
+                .collect();
+        }
+        crate::ui::tree::flatten(&self.groups, collapsed)
+            .into_iter()
+            .map(|row| match row {
+                crate::ui::tree::Row::Parent { group, collapsed } => {
+                    ConnRow::Parent { group, collapsed }
+                }
+                crate::ui::tree::Row::Child { item, .. } => ConnRow::Conn { conn: item },
+            })
+            .collect()
+    }
+}
+
+/// The connection under the cursor, or `None` when a group header is selected.
+///
+/// Every action that operates on "the selected connection" — traceroute,
+/// whois, drill to packets, the detail strip — resolves through here, so a
+/// parent row can never be mistaken for the first connection beneath it.
+pub fn selected_connection(app: &App) -> Option<Connection> {
+    let view = build_view(app);
+    let rows = view.rows(&app.ui.connection_collapsed);
+    let idx = app
+        .ui
+        .scroll
+        .connection_scroll
+        .min(rows.len().saturating_sub(1));
+    match rows.get(idx)? {
+        ConnRow::Conn { conn } => Some((*conn).clone()),
+        ConnRow::Parent { .. } => None,
+    }
+}
+
+/// The group key under the cursor, from a parent row or any of its children.
+pub fn selected_group_key(app: &App) -> Option<String> {
+    let view = build_view(app);
+    if view.groups.is_empty() {
+        return None;
+    }
+    let rows = view.rows(&app.ui.connection_collapsed);
+    let idx = app
+        .ui
+        .scroll
+        .connection_scroll
+        .min(rows.len().saturating_sub(1));
+    // Walk back to the nearest header so folding works from a child row —
+    // navigating up to the parent first would be busywork.
+    rows.get(..=idx)?.iter().rev().find_map(|r| match r {
+        ConnRow::Parent { group, .. } => Some(group.key.clone()),
+        ConnRow::Conn { .. } => None,
+    })
+}
+
+/// Number of visible rows, for clamping scroll against what is on screen.
+pub fn visible_row_count(app: &App) -> usize {
+    build_view(app).rows(&app.ui.connection_collapsed).len()
+}
+
 /// Compact geo string for the Connections GEO column. Prefers
 /// `country_code-city` (e.g. "US-Ashburn"), falls back to country code, and
 /// returns an em-dash for private/unresolved IPs so the column always has a
@@ -574,13 +790,27 @@ fn host_only(addr: &str) -> String {
 
 fn render_connection_table(f: &mut Frame, app: &App, area: Rect) {
     let t = &app.theme;
-    let conns = filtered_sorted_conns(app);
+    let view = build_view(app);
+    let rows = view.rows(&app.ui.connection_collapsed);
+    let conn_count = if view.groups.is_empty() {
+        view.flat.len()
+    } else {
+        view.groups.iter().map(|g| g.rollup.conns).sum()
+    };
 
-    let title_right = format!(
-        " {} shown  group: {} ",
-        conns.len(),
-        app.ui.connection_group.label()
-    );
+    let title_right = if view.groups.is_empty() {
+        format!(" {conn_count} shown  group: none ")
+    } else {
+        let noun = match app.ui.connection_group {
+            ConnectionGroup::Remote => "hosts",
+            _ => "processes",
+        };
+        format!(
+            " {} {noun} · {conn_count} conns  group: {} ",
+            view.groups.len(),
+            app.ui.connection_group.label()
+        )
+    };
     let block = Block::default()
         .title(Line::from(Span::styled(
             " CONNECTIONS ",
@@ -622,12 +852,12 @@ fn render_connection_table(f: &mut Frame, app: &App, area: Rect) {
     );
 
     let visible_rows = inner.height.saturating_sub(1) as usize;
-    let max_idx = conns.len().saturating_sub(1);
+    let max_idx = rows.len().saturating_sub(1);
     let selected = app.ui.scroll.connection_scroll.min(max_idx);
-    let window_top = compute_window_top(selected, conns.len(), visible_rows);
+    let window_top = compute_window_top(selected, rows.len(), visible_rows);
 
-    let rendered = conns.iter().skip(window_top).take(visible_rows).count();
-    for (i, conn) in conns.iter().skip(window_top).take(visible_rows).enumerate() {
+    let rendered = rows.iter().skip(window_top).take(visible_rows).count();
+    for (i, row) in rows.iter().skip(window_top).take(visible_rows).enumerate() {
         let abs_idx = window_top + i;
         let is_selected = abs_idx == selected;
         let row_y = inner.y + 1 + i as u16;
@@ -638,10 +868,24 @@ fn render_connection_table(f: &mut Frame, app: &App, area: Rect) {
         } else {
             1.0
         };
-        render_conn_row(f, app, inner, row_y, conn, is_selected, row_alpha);
+        match row {
+            ConnRow::Conn { conn } => {
+                render_conn_row(f, app, inner, row_y, conn, is_selected, row_alpha)
+            }
+            ConnRow::Parent { group, collapsed } => render_group_row(
+                f,
+                app,
+                inner,
+                row_y,
+                group,
+                *collapsed,
+                is_selected,
+                row_alpha,
+            ),
+        }
     }
 
-    if conns.is_empty() {
+    if rows.is_empty() {
         let empty_area = Rect {
             x: inner.x + 2,
             y: inner.y + 1,
@@ -656,6 +900,174 @@ fn render_connection_table(f: &mut Frame, app: &App, area: Rect) {
             empty_area,
         );
     }
+}
+
+/// A group header: the key named once, with the rollup of everything folded
+/// beneath it.
+///
+/// Laid out on the same column grid as `render_conn_row` so an expanded tree
+/// still reads as one table — a header with its own private alignment would
+/// make the children look like a different screen. Each cell answers the
+/// question its column asks, at group scale: PROTO becomes the child count,
+/// REMOTE becomes how many distinct things are inside, STATE becomes the
+/// dominant state, and the rates are sums.
+#[allow(clippy::too_many_arguments)]
+fn render_group_row(
+    f: &mut Frame,
+    app: &App,
+    inner: Rect,
+    row_y: u16,
+    group: &ConnGroup,
+    collapsed: bool,
+    is_selected: bool,
+    row_alpha: f32,
+) {
+    let t = &app.theme;
+    let r = &group.rollup;
+    let chevron = if collapsed { "▶ " } else { "▼ " };
+    // The group name gets the full 20-char cell the child rows split between
+    // process and PID — the point of the tree is that the name is legible.
+    let name = truncate(&group.key, 20);
+
+    let facet_label = match app.ui.connection_group {
+        ConnectionGroup::Remote => {
+            if r.facets == 1 {
+                "1 proc".to_string()
+            } else {
+                format!("{} procs", r.facets)
+            }
+        }
+        _ => {
+            if r.facets == 1 {
+                "1 pid".to_string()
+            } else {
+                format!("{} pids", r.facets)
+            }
+        }
+    };
+
+    let state_cell = if r.state_count == r.conns {
+        truncate(&r.state, 12).to_string()
+    } else {
+        // Mixed states: say which dominates and how many, rather than
+        // picking one and implying the group is uniform.
+        format!("{} {}/{}", truncate(&r.state, 6), r.state_count, r.conns)
+    };
+    let state_color = match r.state.as_str() {
+        "ESTABLISHED" => t.status_good,
+        "LISTEN" => t.status_info,
+        "TIME_WAIT" | "TIME-WAIT" => t.status_warn,
+        _ => t.text_muted,
+    };
+
+    let rx_str = if r.rx_rate > 0.0 {
+        crate::ui::widgets::format_bytes_rate(r.rx_rate)
+    } else {
+        "—".into()
+    };
+    let tx_str = if r.tx_rate > 0.0 {
+        crate::ui::widgets::format_bytes_rate(r.tx_rate)
+    } else {
+        "—".into()
+    };
+    let rtt_str = r
+        .rtt_us
+        .map(|us| {
+            let ms = us / 1000.0;
+            if ms < 1.0 {
+                format!("{ms:.1}ms")
+            } else {
+                format!("{ms:.0}ms")
+            }
+        })
+        .unwrap_or_else(|| "—".into());
+
+    let mut spans: Vec<Span> = vec![
+        // The chevron stays on the selected row: fold state is information
+        // the selection highlight already conveys separately, and swapping it
+        // for a cursor glyph would hide whether the group is open.
+        Span::styled(chevron, Style::default().fg(t.brand)),
+        // The group name carries the row's weight; the children sit at
+        // normal intensity beneath it.
+        Span::styled(
+            format!("{name:<20}"),
+            Style::default().fg(t.text_primary).bold(),
+        ),
+        // PROTO belongs to an individual flow, so a rollup leaves it empty
+        // rather than putting a count under a header that promises a
+        // protocol. The summary goes in the REMOTE cell, which is where the
+        // eye already is and which has the width to spell it out.
+        Span::raw(" "),
+        Span::styled("     ".to_string(), Style::default().fg(t.text_muted)),
+        Span::raw(" "),
+        Span::styled(
+            format!(
+                "{:<32}",
+                truncate(
+                    &format!(
+                        "{} conn{} · {facet_label}",
+                        r.conns,
+                        if r.conns == 1 { "" } else { "s" }
+                    ),
+                    32
+                )
+            ),
+            Style::default().fg(t.text_secondary),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:<22}", if r.degraded { "retransmits" } else { "" }),
+            Style::default().fg(if r.degraded {
+                t.status_error
+            } else {
+                t.text_muted
+            }),
+        ),
+    ];
+
+    if app.ui.show_geo {
+        // Geo is a property of one endpoint, so a rollup has nothing honest
+        // to put here. Hold the column so the children stay aligned.
+        spans.push(Span::styled(
+            format!(" {:<12}", ""),
+            Style::default().fg(t.text_muted),
+        ));
+    }
+
+    spans.extend([
+        Span::styled(
+            format!(" {:<12}", truncate(&state_cell, 12)),
+            Style::default().fg(state_color),
+        ),
+        Span::styled(format!(" {rx_str:>10}"), Style::default().fg(t.rx_rate)),
+        Span::raw(" "),
+        Span::styled(format!(" {tx_str:>9}"), Style::default().fg(t.tx_rate)),
+        Span::raw(" "),
+        Span::styled(
+            format!(" {rtt_str:>5}"),
+            Style::default().fg(t.text_primary),
+        ),
+        Span::raw(" "),
+        Span::styled(format!(" {:>4}", ""), Style::default().fg(t.text_muted)),
+    ]);
+
+    let faded_spans = if (row_alpha - 1.0).abs() < f32::EPSILON {
+        spans
+    } else {
+        crate::graph::fade_spans_fg(spans, t.bg, row_alpha, t.defers_to_terminal())
+    };
+    let row_area = Rect {
+        x: inner.x + 1,
+        y: row_y,
+        width: inner.width.saturating_sub(2),
+        height: 1,
+    };
+    let para = if is_selected {
+        Paragraph::new(Line::from(faded_spans)).style(Style::default().bg(t.selection_bg))
+    } else {
+        Paragraph::new(Line::from(faded_spans))
+    };
+    f.render_widget(para, row_area);
 }
 
 fn render_conn_row(
@@ -686,7 +1098,14 @@ fn render_conn_row(
         .map(|p| p.to_string())
         .unwrap_or_else(|| "—".into());
     let process = conn.process_name.as_deref().unwrap_or("—");
-    let proc_label = format!("{:<14} {:>5}", truncate(process, 14), pid_str);
+    // Under a tree, the parent row already names the group. Restating it on
+    // every child is what made the flat table unreadable — `claude` eleven
+    // times down a column too narrow to spell `Google Chrome Helper`. Indent
+    // instead, and spend the width on what actually differs.
+    let proc_label = match app.ui.connection_group {
+        ConnectionGroup::Process => format!("    {:>5}{:<10}", pid_str, ""),
+        _ => format!("{:<14} {:>5}", truncate(process, 14), pid_str),
+    };
 
     let proto_color = if conn.protocol.eq_ignore_ascii_case("UDP") {
         t.proto_udp()
@@ -748,7 +1167,24 @@ fn render_conn_row(
         ),
         Span::raw(" "),
         Span::styled(
-            format!("{:<32}", truncate(&conn.remote_addr, 32)),
+            // Same reasoning under `group: remote`: the host is the parent's
+            // name, so the child shows the port that distinguishes it.
+            match app.ui.connection_group {
+                ConnectionGroup::Remote => {
+                    let host = host_only(&conn.remote_addr);
+                    let port = conn
+                        .remote_addr
+                        .rsplit_once(':')
+                        .map(|(_, p)| p.to_string())
+                        .unwrap_or_default();
+                    if port.is_empty() {
+                        format!("    {:<28}", truncate(&host, 28))
+                    } else {
+                        format!("    :{port:<27}")
+                    }
+                }
+                _ => format!("{:<32}", truncate(&conn.remote_addr, 32)),
+            },
             Style::default().fg(t.text_primary),
         ),
         Span::raw(" "),
@@ -872,20 +1308,21 @@ fn truncate(s: &str, max: usize) -> String {
 
 fn render_detail_strip(f: &mut Frame, app: &App, area: Rect) {
     let t = &app.theme;
-    let conns = filtered_sorted_conns(app);
+    let view = build_view(app);
+    let rows = view.rows(&app.ui.connection_collapsed);
     let selected_idx = app
         .ui
         .scroll
         .connection_scroll
-        .min(conns.len().saturating_sub(1));
-    let selected = if conns.is_empty() {
+        .min(rows.len().saturating_sub(1));
+    let selected = if rows.is_empty() {
         None
     } else {
-        conns.get(selected_idx)
+        rows.get(selected_idx)
     };
 
     let title_left = match selected {
-        Some(c) => {
+        Some(ConnRow::Conn { conn: c }) => {
             let proc = c.process_name.as_deref().unwrap_or("—");
             let host = host_only(&c.remote_addr);
             format!(
@@ -895,6 +1332,12 @@ fn render_detail_strip(f: &mut Frame, app: &App, area: Rect) {
                 host,
             )
         }
+        // A group header has no single flow to detail, so the title carries
+        // the rollup rather than pretending one child stands for all of them.
+        Some(ConnRow::Parent { group, .. }) => format!(
+            " DETAIL  {}  {} connections ",
+            group.key, group.rollup.conns
+        ),
         None => " DETAIL ".to_string(),
     };
 
@@ -919,7 +1362,7 @@ fn render_detail_strip(f: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
-    let Some(conn) = selected else {
+    let hint = |f: &mut Frame, msg: &str| {
         let hint_area = Rect {
             x: inner.x + 2,
             y: inner.y + 1,
@@ -928,12 +1371,34 @@ fn render_detail_strip(f: &mut Frame, app: &App, area: Rect) {
         };
         f.render_widget(
             Paragraph::new(Line::from(Span::styled(
-                "No connection selected",
+                msg.to_string(),
                 Style::default().fg(t.text_muted),
             ))),
             hint_area,
         );
-        return;
+    };
+    let conn = match selected {
+        Some(ConnRow::Conn { conn }) => conn,
+        Some(ConnRow::Parent { group, collapsed }) => {
+            let r = &group.rollup;
+            hint(
+                f,
+                &format!(
+                    "{} · {} connections · {} in, {} out{}   —   space to {}",
+                    group.key,
+                    r.conns,
+                    crate::ui::widgets::format_bytes_rate(r.rx_rate),
+                    crate::ui::widgets::format_bytes_rate(r.tx_rate),
+                    if r.degraded { " · retransmits" } else { "" },
+                    if *collapsed { "expand" } else { "fold" },
+                ),
+            );
+            return;
+        }
+        None => {
+            hint(f, "No connection selected");
+            return;
+        }
     };
 
     // Two-column body: left FLOW + STATS, right RX 30s sparkline placeholder
@@ -1150,16 +1615,28 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect) {
             Span::raw(":Quit"),
         ]
     } else {
-        vec![
+        let mut v = vec![
             Span::styled("s", Style::default().fg(app.theme.key_hint).bold()),
             Span::raw(":Sort  "),
             Span::styled("/", Style::default().fg(app.theme.key_hint).bold()),
             Span::raw(":Filter  "),
+        ];
+        // Only advertise folding when there is something to fold — under
+        // `group: none` the key does nothing and the hint would be a lie.
+        if !matches!(app.ui.connection_group, ConnectionGroup::None) {
+            v.push(Span::styled(
+                "space",
+                Style::default().fg(app.theme.key_hint).bold(),
+            ));
+            v.push(Span::raw(":Fold  "));
+        }
+        v.extend([
             Span::styled("T", Style::default().fg(app.theme.key_hint).bold()),
             Span::raw(":Traceroute  "),
             Span::styled("Enter", Style::default().fg(app.theme.key_hint).bold()),
             Span::raw(":→Packets"),
-        ]
+        ]);
+        v
     };
     crate::ui::widgets::render_footer(f, app, area, hints);
 }
@@ -1428,6 +1905,139 @@ mod tests {
             app_protocol: None,
             retransmits: 0,
             out_of_order: 0,
+        }
+    }
+
+    // ── Grouped tree ────────────────────────────────────────────────────
+
+    fn group_of(key: &str, conns: Vec<Connection>, by_process: bool) -> ConnGroup {
+        ConnGroup {
+            key: key.into(),
+            rollup: rollup(by_process, &conns),
+            children: conns,
+        }
+    }
+
+    /// The parent row must summarise its children accurately — a rollup that
+    /// undercounts is worse than no rollup, because the user stops expanding.
+    #[test]
+    fn rollup_summarises_its_children() {
+        let mut a = conn("claude", "ESTABLISHED", "1.2.3.4:443");
+        a.pid = Some(10);
+        a.rx_rate = Some(100.0);
+        a.tx_rate = Some(10.0);
+        a.handshake_rtt_us = Some(5000.0);
+        let mut b = conn("claude", "ESTABLISHED", "5.6.7.8:443");
+        b.pid = Some(11);
+        b.rx_rate = Some(50.0);
+        b.handshake_rtt_us = Some(2000.0);
+        let r = rollup(true, &[a, b]);
+        assert_eq!(r.conns, 2);
+        assert_eq!(r.facets, 2, "two distinct pids");
+        assert_eq!(r.rx_rate, 150.0);
+        assert_eq!(r.tx_rate, 10.0);
+        assert_eq!(r.rtt_us, Some(2000.0), "best RTT, not the first one");
+        assert_eq!(r.state, "ESTABLISHED");
+        assert_eq!(r.state_count, 2);
+        assert!(!r.degraded);
+    }
+
+    /// A rollup must never hide a problem that an expanded child would show.
+    #[test]
+    fn rollup_surfaces_retransmits_from_any_child() {
+        let a = conn("curl", "ESTABLISHED", "1.2.3.4:443");
+        let mut b = conn("curl", "ESTABLISHED", "5.6.7.8:443");
+        b.retransmits = 3;
+        assert!(rollup(true, &[a, b]).degraded);
+    }
+
+    /// UDP rows carry an empty state. Counting them would make "" the winner
+    /// and render the cell as a bare fraction of nothing.
+    #[test]
+    fn dominant_state_ignores_stateless_rows() {
+        let udp = conn("chrome", "", "*:*");
+        let tcp = conn("chrome", "ESTABLISHED", "1.2.3.4:443");
+        let (state, n) = dominant_state(&[udp.clone(), udp.clone(), udp.clone(), tcp]);
+        assert_eq!(state, "ESTABLISHED");
+        assert_eq!(n, 1, "1 of 4 has a named state");
+
+        // All stateless: say so rather than emitting an empty cell.
+        let (state, n) = dominant_state(&[udp.clone(), udp]);
+        assert_eq!(state, "—");
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn rows_emit_a_header_then_its_children_and_fold_hides_only_children() {
+        let groups = vec![
+            group_of(
+                "claude",
+                vec![
+                    conn("claude", "ESTABLISHED", "1.2.3.4:443"),
+                    conn("claude", "ESTABLISHED", "5.6.7.8:443"),
+                ],
+                true,
+            ),
+            group_of("gh", vec![conn("gh", "ESTABLISHED", "9.9.9.9:443")], true),
+        ];
+        let view = ConnView {
+            groups,
+            flat: Vec::new(),
+        };
+
+        let rows = view.rows(&std::collections::HashSet::new());
+        assert_eq!(rows.len(), 5);
+        assert!(matches!(rows[0], ConnRow::Parent { .. }));
+        assert!(matches!(rows[1], ConnRow::Conn { .. }));
+        assert!(matches!(rows[3], ConnRow::Parent { .. }));
+
+        let mut collapsed = std::collections::HashSet::new();
+        collapsed.insert("claude".to_string());
+        let rows = view.rows(&collapsed);
+        assert_eq!(rows.len(), 3, "claude's two children are hidden");
+        assert!(
+            matches!(&rows[0], ConnRow::Parent { group, collapsed } if group.key == "claude" && *collapsed),
+            "the header itself must survive folding"
+        );
+    }
+
+    /// `group: none` is a flat peer list — a tree with one child per parent
+    /// would be strictly worse, so it must not grow headers.
+    #[test]
+    fn ungrouped_view_has_no_header_rows() {
+        let view = ConnView {
+            groups: Vec::new(),
+            flat: vec![
+                conn("a", "ESTABLISHED", "1.1.1.1:443"),
+                conn("b", "ESTABLISHED", "2.2.2.2:443"),
+            ],
+        };
+        let rows = view.rows(&std::collections::HashSet::new());
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| matches!(r, ConnRow::Conn { .. })));
+    }
+
+    /// Row indices now include headers, so anything that resolves "the
+    /// selected connection" by indexing the *connection* list would silently
+    /// act on the wrong flow. A header must resolve to no connection at all.
+    #[test]
+    fn a_header_row_is_not_a_connection() {
+        let view = ConnView {
+            groups: vec![group_of(
+                "claude",
+                vec![conn("claude", "ESTABLISHED", "1.2.3.4:443")],
+                true,
+            )],
+            flat: Vec::new(),
+        };
+        let rows = view.rows(&std::collections::HashSet::new());
+        assert!(
+            !matches!(rows[0], ConnRow::Conn { .. }),
+            "row 0 is the header, not the connection beneath it"
+        );
+        match &rows[1] {
+            ConnRow::Conn { conn } => assert_eq!(conn.remote_addr, "1.2.3.4:443"),
+            ConnRow::Parent { .. } => panic!("row 1 should be the connection"),
         }
     }
 

--- a/src/ui/connections.rs
+++ b/src/ui/connections.rs
@@ -690,7 +690,7 @@ pub fn build_view(app: &App) -> ConnView {
 impl ConnView {
     /// The visible rows, honouring fold state. Single source of truth for
     /// "what is row N" — renderer and input handlers both go through it.
-    pub fn rows(&self, collapsed: &std::collections::HashSet<String>) -> Vec<ConnRow<'_>> {
+    pub fn rows(&self, fold: &crate::ui::tree::FoldState) -> Vec<ConnRow<'_>> {
         if self.groups.is_empty() {
             return self
                 .flat
@@ -698,7 +698,7 @@ impl ConnView {
                 .map(|conn| ConnRow::Conn { conn })
                 .collect();
         }
-        crate::ui::tree::flatten(&self.groups, collapsed)
+        crate::ui::tree::flatten(&self.groups, fold)
             .into_iter()
             .map(|row| match row {
                 crate::ui::tree::Row::Parent { group, collapsed } => {
@@ -1629,6 +1629,15 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(app.theme.key_hint).bold(),
             ));
             v.push(Span::raw(":Fold  "));
+            v.push(Span::styled(
+                "z",
+                Style::default().fg(app.theme.key_hint).bold(),
+            ));
+            v.push(Span::raw(if app.ui.connection_collapsed.all_collapsed() {
+                ":Expand all  "
+            } else {
+                ":Fold all  "
+            }));
         }
         v.extend([
             Span::styled("T", Style::default().fg(app.theme.key_hint).bold()),
@@ -1985,15 +1994,15 @@ mod tests {
             flat: Vec::new(),
         };
 
-        let rows = view.rows(&std::collections::HashSet::new());
+        let rows = view.rows(&crate::ui::tree::FoldState::new(false));
         assert_eq!(rows.len(), 5);
         assert!(matches!(rows[0], ConnRow::Parent { .. }));
         assert!(matches!(rows[1], ConnRow::Conn { .. }));
         assert!(matches!(rows[3], ConnRow::Parent { .. }));
 
-        let mut collapsed = std::collections::HashSet::new();
-        collapsed.insert("claude".to_string());
-        let rows = view.rows(&collapsed);
+        let mut fold = crate::ui::tree::FoldState::new(false);
+        fold.toggle("claude");
+        let rows = view.rows(&fold);
         assert_eq!(rows.len(), 3, "claude's two children are hidden");
         assert!(
             matches!(&rows[0], ConnRow::Parent { group, collapsed } if group.key == "claude" && *collapsed),
@@ -2012,7 +2021,7 @@ mod tests {
                 conn("b", "ESTABLISHED", "2.2.2.2:443"),
             ],
         };
-        let rows = view.rows(&std::collections::HashSet::new());
+        let rows = view.rows(&crate::ui::tree::FoldState::new(false));
         assert_eq!(rows.len(), 2);
         assert!(rows.iter().all(|r| matches!(r, ConnRow::Conn { .. })));
     }
@@ -2030,7 +2039,7 @@ mod tests {
             )],
             flat: Vec::new(),
         };
-        let rows = view.rows(&std::collections::HashSet::new());
+        let rows = view.rows(&crate::ui::tree::FoldState::new(false));
         assert!(
             !matches!(rows[0], ConnRow::Conn { .. }),
             "row 0 is the header, not the connection beneath it"

--- a/src/ui/egress.rs
+++ b/src/ui/egress.rs
@@ -659,7 +659,10 @@ fn render_tree(f: &mut Frame, app: &App, area: Rect) {
                 Constraint::Length(9),  // in
                 Constraint::Length(8),  // activity
                 Constraint::Length(7),  // active
-                Constraint::Length(11), // policy
+                // 12 fits the longest verdict, `✗ undeclared` — at 11 it
+                // rendered as "✗ undeclare", which reads as a rendering bug
+                // on the column whose whole job is to be believed.
+                Constraint::Length(12), // policy
             ],
         )
         .header(header)
@@ -861,39 +864,83 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect) {
         f.render_widget(Paragraph::new(line).style(Style::default().bg(t.bg)), area);
         return;
     }
+    // A destructive edit takes the whole footer and names the part that
+    // cannot be undone, rather than a bare "are you sure".
+    if let Some(process) = &app.ui.egress_pending_removal {
+        let lines = vec![
+            Line::from(vec![
+                Span::styled(" Remove ", Style::default().fg(t.status_error).bold()),
+                Span::styled(process.clone(), Style::default().fg(t.text_primary).bold()),
+                Span::styled(
+                    " from the egress policy?",
+                    Style::default().fg(t.text_primary),
+                ),
+            ]),
+            Line::from(vec![Span::styled(
+                " Hand-written entries are discarded — re-adding only restores what was observed.",
+                Style::default().fg(t.text_muted),
+            )]),
+            Line::from(vec![
+                Span::styled(" y", Style::default().fg(t.key_hint).bold()),
+                Span::raw(" remove   "),
+                Span::styled("any other key", Style::default().fg(t.key_hint).bold()),
+                Span::raw(" cancel"),
+            ]),
+        ];
+        f.render_widget(Paragraph::new(lines).style(Style::default().bg(t.bg)), area);
+        return;
+    }
     let hint = |k: &'static str, label: &'static str| {
         vec![
             Span::styled(k, Style::default().fg(t.key_hint).bold()),
             Span::raw(format!(" {label}   ")),
         ]
     };
-    let mut spans = vec![Span::raw(" ")];
-    spans.extend(hint("s", "sort"));
-    spans.extend(hint("/", "filter"));
-    spans.extend(hint("space", "fold"));
-    spans.extend(hint("d", "detail"));
-    spans.extend(hint("↵", "promote"));
-    spans.extend(hint("e", "export"));
+    // Navigation on the first line, the actions that write to the policy file
+    // on the second. Two lines because the policy actions deserve their real
+    // names — "promote" is jargon for "add to policy", and a destructive
+    // action should not be a bare letter buried in a run of six.
+    let mut nav = vec![Span::raw(" ")];
+    nav.extend(hint("s", "sort"));
+    nav.extend(hint("/", "filter"));
+    nav.extend(hint("space", "fold"));
+    nav.extend(hint("d", "detail"));
     // Teach the two glyphs that aren't self-evident, rather than restating
     // that the linter never blocks — that belongs in the docs, not on every
     // frame.
-    spans.push(Span::styled("~ asn", Style::default().fg(t.status_warn)));
-    spans.push(Span::styled(
+    nav.push(Span::styled("~ asn", Style::default().fg(t.status_warn)));
+    nav.push(Span::styled(
         " = whole-AS match   ",
         Style::default().fg(t.text_muted),
     ));
-    spans.push(Span::styled(
+    nav.push(Span::styled(
         "— no rule",
         Style::default().fg(t.status_warn),
     ));
-    spans.push(Span::styled(
+    nav.push(Span::styled(
         " = unchecked",
         Style::default().fg(t.text_muted),
     ));
-    f.render_widget(
-        Paragraph::new(Line::from(spans)).style(Style::default().bg(t.bg)),
-        area,
-    );
+
+    let mut actions = vec![Span::raw(" ")];
+    actions.extend(hint("↵", "add to policy"));
+    actions.extend(hint("x", "remove from policy"));
+    actions.extend(hint("P", "add all"));
+    actions.extend(hint("e", "export"));
+
+    // The shared header slot for `export_status` sits on the row the tab bar
+    // consumes at any ordinary width, so on this tab the outcome of a policy
+    // edit was never actually visible — a key that declines to act looked
+    // identical to a key that does nothing. Say it here, where there is room.
+    let mut lines = vec![Line::from(nav), Line::from(actions)];
+    if let Some(status) = &app.ui.export_status {
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(status.clone(), Style::default().fg(t.status_good)),
+        ]));
+    }
+
+    f.render_widget(Paragraph::new(lines).style(Style::default().bg(t.bg)), area);
 }
 
 #[cfg(test)]

--- a/src/ui/egress.rs
+++ b/src/ui/egress.rs
@@ -51,6 +51,25 @@ pub enum EgressRow<'a> {
     },
 }
 
+/// Attention ordering over verdicts — lower is more urgent. Drives both the
+/// risk sort and the rollup verdict a collapsed process shows.
+///
+/// `Undeclared` outranks `Drift`: drift is declared software reaching
+/// somewhere new, whereas an undeclared process is a program the operator
+/// never accounted for at all, under a policy that says they accounted for
+/// everything. `NoRule` is the same absence without that claim, so it sits
+/// below both — worth surfacing, not yet a finding.
+fn verdict_rank(v: &Verdict) -> u8 {
+    match v {
+        Verdict::Undeclared => 0,
+        Verdict::Drift => 1,
+        Verdict::NoRule => 2,
+        Verdict::Asn(_) => 3,
+        Verdict::Ech => 4,
+        _ => 5,
+    }
+}
+
 /// Flatten the profiles into the visible row list, honouring filter,
 /// collapse state and sort. Public so the mouse handler maps clicks against
 /// exactly the rows the renderer drew.
@@ -132,15 +151,9 @@ pub fn visible_rows(app: &App) -> Vec<EgressRow<'_>> {
         EgressSort::Risk => groups.sort_by(|a, b| {
             let rank = |g: &Group<'_>| {
                 g.1.iter()
-                    .map(|(_, _, v)| match v {
-                        Verdict::Drift => 0,
-                        Verdict::NoRule => 1,
-                        Verdict::Asn(_) => 2,
-                        Verdict::Ech => 3,
-                        _ => 4,
-                    })
+                    .map(|(_, _, v)| verdict_rank(v))
                     .min()
-                    .unwrap_or(4)
+                    .unwrap_or(u8::MAX)
             };
             rank(a).cmp(&rank(b)).then_with(|| key(b).0.cmp(&key(a).0))
         }),
@@ -154,13 +167,7 @@ pub fn visible_rows(app: &App) -> Vec<EgressRow<'_>> {
         let worst = dests
             .iter()
             .map(|(_, _, v)| v.clone())
-            .min_by_key(|v| match v {
-                Verdict::Drift => 0,
-                Verdict::NoRule => 1,
-                Verdict::Asn(_) => 2,
-                Verdict::Ech => 3,
-                _ => 4,
-            })
+            .min_by_key(verdict_rank)
             .unwrap_or(Verdict::NoPolicy);
         rows.push(EgressRow::Process {
             profile,
@@ -331,32 +338,14 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
             _ => None,
         })
         .sum();
-    // The two counts the policy analysis called critical, on the default
-    // screen: how much is unchecked, and how much is admitted ASN-wide.
-    let unchecked = rows
-        .iter()
-        .filter(|r| {
-            matches!(
-                r,
-                EgressRow::Process {
-                    worst: Verdict::NoRule,
-                    ..
-                }
-            )
-        })
-        .count();
-    let asn_wide = rows
-        .iter()
-        .filter(|r| {
-            matches!(
-                r,
-                EgressRow::Dest {
-                    verdict: Verdict::Asn(_),
-                    ..
-                }
-            )
-        })
-        .count();
+    // The counts the policy analysis called critical, on the default screen:
+    // what was never checked, what a complete policy failed to declare, and
+    // what is admitted ASN-wide.
+    let Tally {
+        undeclared,
+        no_rule,
+        asn_wide,
+    } = tally(&rows);
 
     let mut extra = vec![
         Span::raw("  "),
@@ -374,9 +363,15 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
         ));
     }
     if app.egress_profiler.has_policy() {
-        if unchecked > 0 {
+        if undeclared > 0 {
             extra.push(Span::styled(
-                format!("  ·  {unchecked} undeclared"),
+                format!("  ·  {undeclared} undeclared"),
+                Style::default().fg(t.status_error).bold(),
+            ));
+        }
+        if no_rule > 0 {
+            extra.push(Span::styled(
+                format!("  ·  {no_rule} unchecked"),
                 Style::default().fg(t.status_warn).bold(),
             ));
         }
@@ -386,7 +381,7 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(t.status_warn).bold(),
             ));
         }
-        if unchecked == 0 && asn_wide == 0 {
+        if undeclared == 0 && no_rule == 0 && asn_wide == 0 {
             extra.push(Span::styled(
                 "  ·  policy: all precise",
                 Style::default().fg(t.status_good),
@@ -399,6 +394,46 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
         ));
     }
     widgets::render_header_with_extra(f, app, area, extra);
+}
+
+/// The attention counts, shared by the header line and the panel title so
+/// the two can never disagree.
+///
+/// `undeclared` and `no_rule` are the same underlying absence read under
+/// different policies, and they are counted separately on purpose: one is a
+/// finding the operator asked for, the other is coverage they haven't
+/// claimed yet. Both are per *process*; `asn_wide` is per destination,
+/// because breadth is a property of the individual match.
+struct Tally {
+    undeclared: usize,
+    no_rule: usize,
+    asn_wide: usize,
+}
+
+fn tally(rows: &[EgressRow<'_>]) -> Tally {
+    let mut out = Tally {
+        undeclared: 0,
+        no_rule: 0,
+        asn_wide: 0,
+    };
+    for r in rows {
+        match r {
+            EgressRow::Process {
+                worst: Verdict::Undeclared,
+                ..
+            } => out.undeclared += 1,
+            EgressRow::Process {
+                worst: Verdict::NoRule,
+                ..
+            } => out.no_rule += 1,
+            EgressRow::Dest {
+                verdict: Verdict::Asn(_),
+                ..
+            } => out.asn_wide += 1,
+            _ => {}
+        }
+    }
+    out
 }
 
 /// The counts that decide whether the operator needs to care, rendered for
@@ -424,30 +459,11 @@ fn summary_line(app: &App, rows: &[EgressRow<'_>]) -> Line<'static> {
             _ => None,
         })
         .sum();
-    let unchecked = rows
-        .iter()
-        .filter(|r| {
-            matches!(
-                r,
-                EgressRow::Process {
-                    worst: Verdict::NoRule,
-                    ..
-                }
-            )
-        })
-        .count();
-    let asn_wide = rows
-        .iter()
-        .filter(|r| {
-            matches!(
-                r,
-                EgressRow::Dest {
-                    verdict: Verdict::Asn(_),
-                    ..
-                }
-            )
-        })
-        .count();
+    let Tally {
+        undeclared,
+        no_rule,
+        asn_wide,
+    } = tally(rows);
 
     let mut spans = vec![
         Span::styled(" Egress ", Style::default().fg(t.brand).bold()),
@@ -463,9 +479,15 @@ fn summary_line(app: &App, rows: &[EgressRow<'_>]) -> Line<'static> {
         ));
     }
     if app.egress_profiler.has_policy() {
-        if unchecked > 0 {
+        if undeclared > 0 {
             spans.push(Span::styled(
-                format!(" · {unchecked} undeclared"),
+                format!(" · {undeclared} undeclared"),
+                Style::default().fg(t.status_error).bold(),
+            ));
+        }
+        if no_rule > 0 {
+            spans.push(Span::styled(
+                format!(" · {no_rule} unchecked"),
                 Style::default().fg(t.status_warn).bold(),
             ));
         }
@@ -475,7 +497,7 @@ fn summary_line(app: &App, rows: &[EgressRow<'_>]) -> Line<'static> {
                 Style::default().fg(t.status_warn).bold(),
             ));
         }
-        if unchecked == 0 && asn_wide == 0 {
+        if undeclared == 0 && no_rule == 0 && asn_wide == 0 {
             spans.push(Span::styled(
                 " · all precise",
                 Style::default().fg(t.status_good),
@@ -672,6 +694,8 @@ fn verdict_style(t: &crate::theme::Theme, v: &Verdict, rollup: bool) -> (Color, 
         Verdict::Ech => (t.status_warn, v.label().to_string()),
         Verdict::Drift => (t.status_error, v.label().to_string()),
         Verdict::NoRule => (t.status_warn, v.label().to_string()),
+        // A finding, not a gap — the policy said it was complete.
+        Verdict::Undeclared => (t.status_error, v.label().to_string()),
         Verdict::NoPolicy => (t.text_muted, v.label().to_string()),
     }
 }

--- a/src/ui/egress.rs
+++ b/src/ui/egress.rs
@@ -161,7 +161,7 @@ pub fn visible_rows(app: &App) -> Vec<EgressRow<'_>> {
 
     let mut rows = Vec::new();
     for (profile, dests) in groups {
-        let collapsed = app.ui.egress_collapsed.contains(&profile.process);
+        let collapsed = app.ui.egress_collapsed.is_collapsed(&profile.process);
         let bytes_out = dests.iter().map(|(_, d, _)| d.bytes_out).sum();
         let bytes_in = dests.iter().map(|(_, d, _)| d.bytes_in).sum();
         let worst = dests
@@ -580,8 +580,11 @@ fn render_tree(f: &mut Frame, app: &App, area: Rect) {
                             .bg(bg)
                             .add_modifier(Modifier::BOLD),
                     ),
-                    Cell::from(format!("{dests} dests"))
-                        .style(Style::default().fg(t.text_muted).bg(bg)),
+                    Cell::from(format!(
+                        "{dests} dest{}",
+                        if *dests == 1 { "" } else { "s" }
+                    ))
+                    .style(Style::default().fg(t.text_muted).bg(bg)),
                     Cell::from(vol(*bytes_out)).style(Style::default().fg(t.tx_rate).bg(bg)),
                     Cell::from(vol(*bytes_in)).style(Style::default().fg(t.rx_rate).bg(bg)),
                     Cell::from(spark(activity, spark_w))
@@ -904,6 +907,14 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     nav.extend(hint("s", "sort"));
     nav.extend(hint("/", "filter"));
     nav.extend(hint("space", "fold"));
+    nav.extend(hint(
+        "z",
+        if app.ui.egress_collapsed.all_collapsed() {
+            "expand all"
+        } else {
+            "fold all"
+        },
+    ));
     nav.extend(hint("d", "detail"));
     // Teach the two glyphs that aren't self-evident, rather than restating
     // that the linter never blocks — that belongs in the docs, not on every

--- a/src/ui/egress.rs
+++ b/src/ui/egress.rs
@@ -1,298 +1,932 @@
-//! Egress tab (Horizon 3) — per-process egress profiles and policy drift.
+//! Egress tab — per-process egress profiles and policy drift.
 //!
 //! Shows what each process talks to (SNI / ASN / port) as learned by the
 //! `EgressProfiler`, and — when an `egress-policy.toml` is loaded — whether
-//! each destination is within the declared allowlist. `Shift+P` promotes the
-//! current baseline into that policy. Read-only: the linter warns, it never
-//! blocks.
+//! each destination is within the declared allowlist. Read-only: the linter
+//! warns, it never blocks.
+//!
+//! The data is a tree (process → destinations) and is rendered as one. The
+//! flat table this replaced repeated the process name on every row, spent a
+//! whole column restating the destination as an IP, and showed a raw
+//! observation count that was really a dwell time in seconds.
 
 use crate::app::App;
+use crate::collectors::egress::{EgressDest, EgressProfile, Verdict};
+use crate::state::EgressSort;
 use crate::ui::widgets;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Cell, Paragraph, Row, Table},
 };
 
+const SPARK: &[char] = &['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+/// Rows of chrome above the table body: tab bar (3) + table border + header.
+const HEADER_ROWS: u16 = 3;
+
+/// A destination paired with its display label and policy verdict.
+type ScoredDest<'a> = (&'a str, &'a EgressDest, Verdict);
+/// A process and its (filtered, sorted) destinations.
+type Group<'a> = (&'a EgressProfile, Vec<ScoredDest<'a>>);
+
+/// One line of the rendered tree.
+pub enum EgressRow<'a> {
+    /// A process, carrying the rollup of its destinations.
+    Process {
+        profile: &'a EgressProfile,
+        dests: usize,
+        bytes_out: u64,
+        bytes_in: u64,
+        activity: Vec<u64>,
+        /// Worst verdict across the process's destinations — what the
+        /// operator needs to see without expanding.
+        worst: Verdict,
+        collapsed: bool,
+    },
+    /// A destination beneath the process above it.
+    Dest {
+        process: &'a str,
+        label: &'a str,
+        dest: &'a EgressDest,
+        verdict: Verdict,
+    },
+}
+
+/// Flatten the profiles into the visible row list, honouring filter,
+/// collapse state and sort. Public so the mouse handler maps clicks against
+/// exactly the rows the renderer drew.
+pub fn visible_rows(app: &App) -> Vec<EgressRow<'_>> {
+    let profiles = app.egress_profiler.profiles_ref();
+    let needle = app
+        .ui
+        .egress_filter_active
+        .as_deref()
+        .map(str::to_lowercase);
+
+    let mut groups: Vec<Group<'_>> = Vec::new();
+    for profile in profiles {
+        let mut dests: Vec<ScoredDest<'_>> = profile
+            .dests
+            .iter()
+            .map(|((label, _), d)| {
+                (
+                    label.as_str(),
+                    d,
+                    app.egress_profiler.verdict(&profile.process, d),
+                )
+            })
+            .filter(|(label, d, _)| match needle.as_deref() {
+                None => true,
+                // Match the process or any of its destination identities, so
+                // filtering by "google" finds both a process named that and
+                // anything talking to it.
+                Some(n) => {
+                    profile.process.to_lowercase().contains(n)
+                        || label.to_lowercase().contains(n)
+                        || d.sni
+                            .as_deref()
+                            .is_some_and(|s| s.to_lowercase().contains(n))
+                        || d.asn_org
+                            .as_deref()
+                            .is_some_and(|s| s.to_lowercase().contains(n))
+                        || d.last_ip.contains(n)
+                }
+            })
+            .collect();
+        if dests.is_empty() {
+            continue;
+        }
+        // Destinations always by volume then dwell — within one process the
+        // question is always "what did it talk to most".
+        dests.sort_by(|a, b| {
+            b.1.bytes_out
+                .cmp(&a.1.bytes_out)
+                .then_with(|| b.1.count.cmp(&a.1.count))
+        });
+        groups.push((profile, dests));
+    }
+
+    let key = |g: &Group<'_>| -> (u64, u64, u64) {
+        let out: u64 = g.1.iter().map(|(_, d, _)| d.bytes_out).sum();
+        let active: u64 = g.1.iter().map(|(_, d, _)| d.count).max().unwrap_or(0);
+        let last: u64 =
+            g.1.iter()
+                .map(|(_, d, _)| {
+                    d.last_seen
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|x| x.as_secs())
+                        .unwrap_or(0)
+                })
+                .max()
+                .unwrap_or(0);
+        (out, active, last)
+    };
+    match app.ui.egress_sort {
+        EgressSort::Volume => groups.sort_by_key(|g| std::cmp::Reverse(key(g).0)),
+        EgressSort::Active => groups.sort_by_key(|g| std::cmp::Reverse(key(g).1)),
+        EgressSort::LastSeen => groups.sort_by_key(|g| std::cmp::Reverse(key(g).2)),
+        EgressSort::Process => groups.sort_by(|a, b| a.0.process.cmp(&b.0.process)),
+        // Risk: anything unchecked or broadly admitted floats up. This is the
+        // ordering that answers "what should I look at" rather than "what is
+        // biggest", and it surfaces exactly the two findings the policy
+        // analysis called critical.
+        EgressSort::Risk => groups.sort_by(|a, b| {
+            let rank = |g: &Group<'_>| {
+                g.1.iter()
+                    .map(|(_, _, v)| match v {
+                        Verdict::Drift => 0,
+                        Verdict::NoRule => 1,
+                        Verdict::Asn(_) => 2,
+                        Verdict::Ech => 3,
+                        _ => 4,
+                    })
+                    .min()
+                    .unwrap_or(4)
+            };
+            rank(a).cmp(&rank(b)).then_with(|| key(b).0.cmp(&key(a).0))
+        }),
+    }
+
+    let mut rows = Vec::new();
+    for (profile, dests) in groups {
+        let collapsed = app.ui.egress_collapsed.contains(&profile.process);
+        let bytes_out = dests.iter().map(|(_, d, _)| d.bytes_out).sum();
+        let bytes_in = dests.iter().map(|(_, d, _)| d.bytes_in).sum();
+        let worst = dests
+            .iter()
+            .map(|(_, _, v)| v.clone())
+            .min_by_key(|v| match v {
+                Verdict::Drift => 0,
+                Verdict::NoRule => 1,
+                Verdict::Asn(_) => 2,
+                Verdict::Ech => 3,
+                _ => 4,
+            })
+            .unwrap_or(Verdict::NoPolicy);
+        rows.push(EgressRow::Process {
+            profile,
+            dests: dests.len(),
+            bytes_out,
+            bytes_in,
+            activity: merged_activity(&dests),
+            worst,
+            collapsed,
+        });
+        if !collapsed {
+            for (label, dest, verdict) in dests {
+                rows.push(EgressRow::Dest {
+                    process: &profile.process,
+                    label,
+                    dest,
+                    verdict,
+                });
+            }
+        }
+    }
+    rows
+}
+
+/// Sum the per-tick activity of a process's destinations into one series.
+fn merged_activity(dests: &[ScoredDest<'_>]) -> Vec<u64> {
+    let n = dests
+        .iter()
+        .map(|(_, d, _)| d.activity.len())
+        .max()
+        .unwrap_or(0);
+    (0..n)
+        .map(|i| {
+            dests
+                .iter()
+                .map(|(_, d, _)| {
+                    // Align to the right: series are newest-last and may
+                    // differ in length when a destination appeared later.
+                    let off = n - d.activity.len();
+                    if i >= off {
+                        d.activity[i - off]
+                    } else {
+                        0
+                    }
+                })
+                .sum()
+        })
+        .collect()
+}
+
+/// Block sparkline over a byte series, scaled to its own max.
+fn spark(samples: &[u64], width: usize) -> String {
+    if samples.is_empty() || width == 0 {
+        return String::new();
+    }
+    let tail = &samples[samples.len().saturating_sub(width)..];
+    let max = *tail.iter().max().unwrap_or(&0);
+    if max == 0 {
+        // All-zero is a real answer — a flat floor, not an empty cell.
+        return SPARK[0].to_string().repeat(tail.len());
+    }
+    tail.iter()
+        .map(|v| {
+            let idx = ((*v as f64 / max as f64) * (SPARK.len() - 1) as f64).round() as usize;
+            SPARK[idx.min(SPARK.len() - 1)]
+        })
+        .collect()
+}
+
+/// Dwell rendered as a duration. `count` increments once per ~1 s connection
+/// tick, so it is seconds — showing it as a bare number reads as a request
+/// count, which it is not.
+fn dwell(count: u64) -> String {
+    match count {
+        0 => "—".into(),
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m", s / 60),
+        s if s < 86_400 => format!("{:.1}h", s as f64 / 3600.0),
+        s => format!("{:.1}d", s as f64 / 86_400.0),
+    }
+}
+
+/// Compact byte formatting with a GB step — egress totals reach it.
+fn human_bytes(b: u64) -> String {
+    const K: f64 = 1024.0;
+    let f = b as f64;
+    if f < K {
+        format!("{b} B")
+    } else if f < K * K {
+        format!("{:.0} KB", f / K)
+    } else if f < K * K * K {
+        format!("{:.1} MB", f / (K * K))
+    } else {
+        format!("{:.1} GB", f / (K * K * K))
+    }
+}
+
+/// Process under the cursor — the promote target. Works whether the cursor
+/// is on a process row or one of its destinations.
+pub fn selected_process(app: &App) -> Option<String> {
+    let rows = visible_rows(app);
+    let sel = app
+        .ui
+        .scroll
+        .egress_scroll
+        .min(rows.len().saturating_sub(1));
+    match rows.get(sel)? {
+        EgressRow::Process { profile, .. } => Some(profile.process.clone()),
+        EgressRow::Dest { process, .. } => Some(process.to_string()),
+    }
+}
+
+/// Bytes, or an em dash when capture isn't running and the figure would be a
+/// confident-looking zero.
+fn vol(b: u64) -> String {
+    if b == 0 {
+        "—".into()
+    } else {
+        human_bytes(b)
+    }
+}
+
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
-    // Reserve a warnings panel at the bottom only when there are warnings to
-    // show — otherwise the profile table gets the full height.
     let has_warnings = app.egress_profiler.recent_violation_count() > 0;
-    let warn_h: u16 = if has_warnings { 8 } else { 0 };
+    let warn_h: u16 = if has_warnings { 6 } else { 0 };
+    let detail_h: u16 = if app.ui.egress_detail { 7 } else { 0 };
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),      // header
-            Constraint::Min(5),         // profile table
-            Constraint::Length(warn_h), // warnings panel (0 when none)
-            Constraint::Length(3),      // footer
+            Constraint::Length(3),        // header
+            Constraint::Min(5),           // tree
+            Constraint::Length(detail_h), // detail pane (d)
+            Constraint::Length(warn_h),   // warnings
+            Constraint::Length(3),        // footer
         ])
         .split(area);
 
     render_header(f, app, chunks[0]);
-    render_table(f, app, chunks[1]);
-    if has_warnings {
-        render_warnings(f, app, chunks[2]);
+    render_tree(f, app, chunks[1]);
+    if app.ui.egress_detail {
+        render_detail(f, app, chunks[2]);
     }
-    render_footer(f, app, chunks[3]);
+    if has_warnings {
+        render_warnings(f, app, chunks[3]);
+    }
+    render_footer(f, app, chunks[4]);
 }
 
 fn render_header(f: &mut Frame, app: &App, area: Rect) {
     let t = &app.theme;
-    let procs = app.egress_profiler.process_count();
-    let dests = app.egress_profiler.dest_count();
-    let (policy_text, policy_style) = if app.egress_profiler.has_policy() {
-        (
-            "policy: loaded — warn on drift",
-            Style::default().fg(t.status_good),
-        )
-    } else {
-        (
-            "policy: none (observe only)",
-            Style::default().fg(t.text_muted),
-        )
-    };
-    let extra = vec![
+    let rows = visible_rows(app);
+    let procs = rows
+        .iter()
+        .filter(|r| matches!(r, EgressRow::Process { .. }))
+        .count();
+    let dests: usize = rows
+        .iter()
+        .filter_map(|r| match r {
+            EgressRow::Process { dests, .. } => Some(*dests),
+            _ => None,
+        })
+        .sum();
+    let out: u64 = rows
+        .iter()
+        .filter_map(|r| match r {
+            EgressRow::Process { bytes_out, .. } => Some(*bytes_out),
+            _ => None,
+        })
+        .sum();
+    // The two counts the policy analysis called critical, on the default
+    // screen: how much is unchecked, and how much is admitted ASN-wide.
+    let unchecked = rows
+        .iter()
+        .filter(|r| {
+            matches!(
+                r,
+                EgressRow::Process {
+                    worst: Verdict::NoRule,
+                    ..
+                }
+            )
+        })
+        .count();
+    let asn_wide = rows
+        .iter()
+        .filter(|r| {
+            matches!(
+                r,
+                EgressRow::Dest {
+                    verdict: Verdict::Asn(_),
+                    ..
+                }
+            )
+        })
+        .count();
+
+    let mut extra = vec![
         Span::raw("  "),
         Span::styled("EGRESS", Style::default().fg(t.brand).bold()),
-        Span::raw(format!("  {procs} processes · {dests} destinations  ")),
-        Span::styled(policy_text, policy_style),
+        Span::raw(format!("  {procs} processes · {dests} destinations")),
     ];
+    // Note: on a narrow terminal the tab bar consumes this row entirely, so
+    // the same figures are repeated in the panel title, which always has
+    // room. This line is the bonus on a wide terminal, not the only copy.
+    if out > 0 {
+        extra.push(Span::raw("  ·  "));
+        extra.push(Span::styled(
+            format!("{} out", human_bytes(out)),
+            Style::default().fg(t.text_primary),
+        ));
+    }
+    if app.egress_profiler.has_policy() {
+        if unchecked > 0 {
+            extra.push(Span::styled(
+                format!("  ·  {unchecked} undeclared"),
+                Style::default().fg(t.status_warn).bold(),
+            ));
+        }
+        if asn_wide > 0 {
+            extra.push(Span::styled(
+                format!("  ·  {asn_wide} ASN-wide"),
+                Style::default().fg(t.status_warn).bold(),
+            ));
+        }
+        if unchecked == 0 && asn_wide == 0 {
+            extra.push(Span::styled(
+                "  ·  policy: all precise",
+                Style::default().fg(t.status_good),
+            ));
+        }
+    } else {
+        extra.push(Span::styled(
+            "  ·  observe only (no policy)",
+            Style::default().fg(t.text_muted),
+        ));
+    }
     widgets::render_header_with_extra(f, app, area, extra);
 }
 
-fn render_table(f: &mut Frame, app: &App, area: Rect) {
+/// The counts that decide whether the operator needs to care, rendered for
+/// the panel title. Kept separate from the header so a narrow terminal —
+/// where the tab bar eats the header row — still shows them.
+fn summary_line(app: &App, rows: &[EgressRow<'_>]) -> Line<'static> {
     let t = &app.theme;
-    let profiles = app.egress_profiler.snapshot();
+    let procs = rows
+        .iter()
+        .filter(|r| matches!(r, EgressRow::Process { .. }))
+        .count();
+    let dests: usize = rows
+        .iter()
+        .filter_map(|r| match r {
+            EgressRow::Process { dests, .. } => Some(*dests),
+            _ => None,
+        })
+        .sum();
+    let out: u64 = rows
+        .iter()
+        .filter_map(|r| match r {
+            EgressRow::Process { bytes_out, .. } => Some(*bytes_out),
+            _ => None,
+        })
+        .sum();
+    let unchecked = rows
+        .iter()
+        .filter(|r| {
+            matches!(
+                r,
+                EgressRow::Process {
+                    worst: Verdict::NoRule,
+                    ..
+                }
+            )
+        })
+        .count();
+    let asn_wide = rows
+        .iter()
+        .filter(|r| {
+            matches!(
+                r,
+                EgressRow::Dest {
+                    verdict: Verdict::Asn(_),
+                    ..
+                }
+            )
+        })
+        .count();
 
-    if profiles.is_empty() {
-        let empty = Paragraph::new(
+    let mut spans = vec![
+        Span::styled(" Egress ", Style::default().fg(t.brand).bold()),
+        Span::styled(
+            format!("· {procs} processes · {dests} destinations"),
+            Style::default().fg(t.text_muted),
+        ),
+    ];
+    if out > 0 {
+        spans.push(Span::styled(
+            format!(" · {} out", human_bytes(out)),
+            Style::default().fg(t.text_primary),
+        ));
+    }
+    if app.egress_profiler.has_policy() {
+        if unchecked > 0 {
+            spans.push(Span::styled(
+                format!(" · {unchecked} undeclared"),
+                Style::default().fg(t.status_warn).bold(),
+            ));
+        }
+        if asn_wide > 0 {
+            spans.push(Span::styled(
+                format!(" · {asn_wide} ASN-wide"),
+                Style::default().fg(t.status_warn).bold(),
+            ));
+        }
+        if unchecked == 0 && asn_wide == 0 {
+            spans.push(Span::styled(
+                " · all precise",
+                Style::default().fg(t.status_good),
+            ));
+        }
+    } else {
+        spans.push(Span::styled(
+            " · observe only",
+            Style::default().fg(t.text_muted),
+        ));
+    }
+    spans.push(Span::raw(" "));
+    Line::from(spans)
+}
+
+/// The table's inner rect — shared with the mouse handler so a click maps to
+/// the row the user actually sees (the lesson from issue #28).
+pub fn table_inner_area(area: Rect) -> Rect {
+    Rect {
+        x: area.x + 1,
+        y: area.y + HEADER_ROWS + 1,
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(HEADER_ROWS + 2 + 3),
+    }
+}
+
+fn render_tree(f: &mut Frame, app: &App, area: Rect) {
+    let t = &app.theme;
+    let rows = visible_rows(app);
+
+    if rows.is_empty() {
+        let msg = if app.ui.egress_filter_active.is_some() {
+            "No destinations match the filter.\n\nPress / to edit it, Esc to clear."
+        } else {
             "No egress observed yet.\n\nTraffic to external hosts will appear here, grouped by \
-             process. SNI is read from the cleartext TLS/QUIC ClientHello — no decryption needed.",
-        )
-        .style(Style::default().fg(t.text_muted))
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(t.border)),
+             process. SNI is read from the cleartext TLS/QUIC ClientHello — no decryption needed."
+        };
+        f.render_widget(
+            Paragraph::new(msg)
+                .style(Style::default().fg(t.text_muted))
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(t.border)),
+                ),
+            area,
         );
-        f.render_widget(empty, area);
         return;
     }
 
-    // Flatten profiles → rows, processes alphabetical, destinations by hit
-    // count (descending). `egress_scroll` is the *selected* flat index
-    // (wheel / arrows via `scroll_tab`, clamped against `dest_count`); the
-    // visible window follows the selection, processes-tab style.
-    let body_rows = (area.height.saturating_sub(3)) as usize; // borders + header row
-    let grand_total = app.egress_profiler.dest_count();
+    let body = area.height.saturating_sub(3) as usize;
     let selected = app
         .ui
         .scroll
         .egress_scroll
-        .min(grand_total.saturating_sub(1));
-    let start = (selected + 1).saturating_sub(body_rows);
-    let now = std::time::SystemTime::now();
-    let mut rows: Vec<Row> = Vec::new();
-    let mut shown = 0usize;
-    let mut total = 0usize;
+        .min(rows.len().saturating_sub(1));
+    let start = (selected + 1).saturating_sub(body.max(1));
+    let spark_w = 7usize;
 
-    for profile in &profiles {
-        // Iterate entries, not values: the key's label is the destination's
-        // original identity (SNI, ASN org, or the IP) and is the only copy
-        // that survives when `last_ip` is missing — baselines written before
-        // the `ip` field existed, or rows an unreadable address blanked.
-        let mut dests: Vec<_> = profile.dests.iter().collect();
-        dests.sort_by_key(|(_, d)| std::cmp::Reverse(d.count));
-        for ((label, _), dest) in dests {
-            total += 1;
-            if total <= start || shown >= body_rows {
-                continue;
+    let mut lines: Vec<Row> = Vec::new();
+    for (i, row) in rows.iter().enumerate().skip(start).take(body) {
+        let is_sel = i == selected;
+        let bg = if is_sel { t.selection_bg } else { t.bg };
+        lines.push(match row {
+            EgressRow::Process {
+                profile,
+                dests,
+                bytes_out,
+                bytes_in,
+                activity,
+                worst,
+                collapsed,
+            } => {
+                let chevron = if *collapsed { "▶" } else { "▼" };
+                let (vcol, vtext) = verdict_style(t, worst, true);
+                Row::new(vec![
+                    Cell::from(format!("{chevron} {}", profile.process)).style(
+                        Style::default()
+                            .fg(t.brand)
+                            .bg(bg)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Cell::from(format!("{dests} dests"))
+                        .style(Style::default().fg(t.text_muted).bg(bg)),
+                    Cell::from(vol(*bytes_out)).style(Style::default().fg(t.tx_rate).bg(bg)),
+                    Cell::from(vol(*bytes_in)).style(Style::default().fg(t.rx_rate).bg(bg)),
+                    Cell::from(spark(activity, spark_w))
+                        .style(Style::default().fg(t.text_secondary).bg(bg)),
+                    Cell::from("").style(Style::default().bg(bg)),
+                    Cell::from(vtext).style(Style::default().fg(vcol).bg(bg)),
+                ])
             }
-            let is_selected = total - 1 == selected;
-            // Never hide the endpoint: a nameless row shows its real IP, not
-            // a useless "(ip)" placeholder. Named rows show the name; the
-            // concrete IP is always in its own column and in the export.
-            // The key label is the last resort — it repairs rows whose
-            // `last_ip` is blank without needing a migration.
-            let name = match (&dest.sni, &dest.asn_org, dest.ech) {
-                (Some(s), _, _) => s.clone(),
-                (None, Some(a), _) => a.clone(),
-                (None, None, true) => "(ech — name encrypted)".to_string(),
-                (None, None, false) if !dest.last_ip.is_empty() => dest.last_ip.clone(),
-                (None, None, false) => label.clone(),
-            };
-            // The label is only an address when neither name was recorded —
-            // otherwise it holds the SNI, and showing it here would put a
-            // hostname in the IP column. Same guard as `load_profiles`.
-            let ip_cell = if !dest.last_ip.is_empty() {
-                dest.last_ip.clone()
-            } else if dest.sni.is_none() && dest.asn_org.is_none() {
-                label.clone()
-            } else {
-                "—".to_string()
-            };
-            let (verdict, vstyle) = match app.egress_profiler.dest_allowed(&profile.process, dest) {
-                Some(true) => ("✓ ok", Style::default().fg(t.status_good)),
-                // ECH hides the inner SNI by design — a miss with no readable
-                // name may be "unreadable", not drift. Distinguish it so
-                // encrypted names don't read as red alarms.
-                Some(false) if dest.ech && dest.sni.is_none() => {
-                    ("? ech", Style::default().fg(t.status_warn))
-                }
-                Some(false) => ("✗ drift", Style::default().fg(t.status_error).bold()),
-                None => ("—", Style::default().fg(t.text_muted)),
-            };
-            let row = Row::new(vec![
-                Cell::from(profile.process.clone()).style(Style::default().fg(t.text_primary)),
-                Cell::from(name).style(Style::default().fg(t.text_primary)),
-                Cell::from(ip_cell).style(Style::default().fg(t.text_muted)),
-                Cell::from(dest.port.to_string()).style(Style::default().fg(t.text_secondary)),
-                Cell::from(dest.count.to_string()).style(Style::default().fg(t.text_secondary)),
-                Cell::from(fmt_age(dest.first_seen, now)).style(Style::default().fg(t.text_muted)),
-                Cell::from(fmt_age(dest.last_seen, now))
-                    .style(Style::default().fg(t.text_secondary)),
-                Cell::from(verdict).style(vstyle),
-            ]);
-            rows.push(if is_selected {
-                row.style(Style::default().bg(t.selection_bg))
-            } else {
-                row
-            });
-            shown += 1;
-        }
+            EgressRow::Dest {
+                label,
+                dest,
+                verdict,
+                ..
+            } => {
+                // host:port in one cell — the form everyone reads. The IP is
+                // only shown when it adds something, i.e. when the label is
+                // a name rather than the address itself.
+                let endpoint = format!("    {}:{}", label, dest.port);
+                let (vcol, vtext) = verdict_style(t, verdict, false);
+                Row::new(vec![
+                    Cell::from(endpoint).style(Style::default().fg(t.text_primary).bg(bg)),
+                    Cell::from(if dest.last_ip == *label {
+                        String::new()
+                    } else {
+                        dest.last_ip.clone()
+                    })
+                    .style(Style::default().fg(t.text_muted).bg(bg)),
+                    Cell::from(vol(dest.bytes_out)).style(Style::default().fg(t.tx_rate).bg(bg)),
+                    Cell::from(vol(dest.bytes_in)).style(Style::default().fg(t.rx_rate).bg(bg)),
+                    Cell::from(spark(
+                        &dest.activity.iter().copied().collect::<Vec<_>>(),
+                        spark_w,
+                    ))
+                    .style(Style::default().fg(t.text_secondary).bg(bg)),
+                    Cell::from(dwell(dest.count))
+                        .style(Style::default().fg(t.text_secondary).bg(bg)),
+                    Cell::from(vtext).style(Style::default().fg(vcol).bg(bg)),
+                ])
+            }
+        });
     }
 
     let header = Row::new(vec![
-        "Process",
-        "Destination",
+        "Process / destination",
         "IP",
-        "Port",
-        "Seen",
-        "First",
-        "Last",
+        "Out",
+        "In",
+        "Activity",
+        "Active",
         "Policy",
     ])
     .style(Style::default().fg(t.key_hint).bold());
 
-    let title = if total > shown || start > 0 {
-        let first = (start + 1).min(total);
-        format!(" Egress profiles  ({first}–{} of {total}) ", start + shown)
-    } else {
-        format!(" Egress profiles  ({total}) ")
-    };
-
-    let table = Table::new(
-        rows,
-        [
-            Constraint::Percentage(16), // Process
-            Constraint::Percentage(34), // Destination (name)
-            Constraint::Percentage(22), // IP
-            Constraint::Length(6),      // Port
-            Constraint::Length(6),      // Seen (count)
-            Constraint::Length(7),      // First
-            Constraint::Length(6),      // Last
-            Constraint::Length(8),      // Policy
-        ],
-    )
-    .header(header)
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(t.border))
-            .title(title),
+    let shown = lines.len();
+    let right = format!(
+        " {}–{} of {}  sort[{}]{} ",
+        (start + 1).min(rows.len()),
+        start + shown,
+        rows.len(),
+        app.ui.egress_sort.label(),
+        app.ui
+            .egress_filter_active
+            .as_deref()
+            .map(|x| format!("  filter:\"{x}\""))
+            .unwrap_or_default()
     );
-    f.render_widget(table, area);
+
+    f.render_widget(
+        Table::new(
+            lines,
+            [
+                Constraint::Min(34),    // process / destination
+                Constraint::Length(16), // IP
+                Constraint::Length(9),  // out
+                Constraint::Length(9),  // in
+                Constraint::Length(8),  // activity
+                Constraint::Length(7),  // active
+                Constraint::Length(11), // policy
+            ],
+        )
+        .header(header)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(t.border))
+                .title_top(summary_line(app, &rows))
+                .title_top(
+                    Line::from(Span::styled(right, Style::default().fg(t.text_muted)))
+                        .right_aligned(),
+                ),
+        ),
+        area,
+    );
+}
+
+/// Colour + text for a verdict. `~ asn` and `— no rule` are deliberately
+/// styled as warnings rather than neutral: both mean "admitted without
+/// really being checked", which a tick would hide.
+fn verdict_style(t: &crate::theme::Theme, v: &Verdict, rollup: bool) -> (Color, String) {
+    match v {
+        Verdict::Sni | Verdict::Ip => (t.status_good, v.label().to_string()),
+        Verdict::Asn(org) => (
+            t.status_warn,
+            if rollup {
+                "⚠ asn-wide".to_string()
+            } else {
+                format!("~ {}", truncate(org, 9))
+            },
+        ),
+        Verdict::Ech => (t.status_warn, v.label().to_string()),
+        Verdict::Drift => (t.status_error, v.label().to_string()),
+        Verdict::NoRule => (t.status_warn, v.label().to_string()),
+        Verdict::NoPolicy => (t.text_muted, v.label().to_string()),
+    }
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        s.chars().take(n.saturating_sub(1)).collect::<String>() + "…"
+    }
+}
+
+fn render_detail(f: &mut Frame, app: &App, area: Rect) {
+    let t = &app.theme;
+    let rows = visible_rows(app);
+    let sel = app
+        .ui
+        .scroll
+        .egress_scroll
+        .min(rows.len().saturating_sub(1));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(t.border))
+        .title(" Detail ");
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let Some(row) = rows.get(sel) else { return };
+    let lines: Vec<Line> = match row {
+        EgressRow::Process {
+            profile,
+            dests,
+            bytes_out,
+            bytes_in,
+            worst,
+            ..
+        } => vec![
+            kv(t, "Process", profile.process.clone()),
+            kv(t, "Destinations", format!("{dests}")),
+            kv(
+                t,
+                "Volume",
+                format!("{} out · {} in", vol(*bytes_out), vol(*bytes_in)),
+            ),
+            kv(t, "Worst verdict", worst.label().to_string()),
+        ],
+        EgressRow::Dest {
+            label,
+            dest,
+            verdict,
+            ..
+        } => {
+            // The whole point of the pane: the untruncated name.
+            let mut v = vec![
+                kv(t, "Destination", format!("{}:{}", label, dest.port)),
+                kv(
+                    t,
+                    "Address",
+                    format!(
+                        "{}{}",
+                        if dest.last_ip.is_empty() {
+                            "—"
+                        } else {
+                            &dest.last_ip
+                        },
+                        dest.asn_org
+                            .as_deref()
+                            .map(|a| format!("   ASN  {a}"))
+                            .unwrap_or_default()
+                    ),
+                ),
+                kv(
+                    t,
+                    "Volume",
+                    format!("{} out · {} in", vol(dest.bytes_out), vol(dest.bytes_in)),
+                ),
+                kv(
+                    t,
+                    "Active",
+                    format!(
+                        "{}   ECH  {}",
+                        dwell(dest.count),
+                        if dest.ech { "yes" } else { "no" }
+                    ),
+                ),
+            ];
+            v.push(match verdict {
+                Verdict::Asn(org) => Line::from(vec![
+                    Span::styled(
+                        format!("{:<14}", "Verdict"),
+                        Style::default().fg(t.text_muted),
+                    ),
+                    Span::styled(
+                        format!("~ asn — admitted by autonomous system \"{org}\", not by name."),
+                        Style::default().fg(t.status_warn),
+                    ),
+                ]),
+                other => kv(t, "Verdict", other.label().to_string()),
+            });
+            v
+        }
+    };
+    f.render_widget(
+        Paragraph::new(lines).style(Style::default().bg(t.bg)),
+        inner,
+    );
+}
+
+fn kv(t: &crate::theme::Theme, k: &str, v: String) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{k:<14}"), Style::default().fg(t.text_muted)),
+        Span::styled(v, Style::default().fg(t.text_primary)),
+    ])
+}
+
+fn render_warnings(f: &mut Frame, app: &App, area: Rect) {
+    let t = &app.theme;
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(t.status_error))
+        .title(" Recent drift ");
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let lines: Vec<Line> = app
+        .egress_profiler
+        .recent_violations()
+        .take(inner.height as usize)
+        .map(|v| {
+            Line::from(vec![
+                Span::styled(
+                    format!("{:<20}", truncate(&v.process, 20)),
+                    Style::default().fg(t.text_primary),
+                ),
+                Span::styled(
+                    format!("{}:{}  ", truncate(&v.dest, 34), v.port),
+                    Style::default().fg(t.status_error),
+                ),
+                Span::styled(v.reason.clone(), Style::default().fg(t.text_muted)),
+            ])
+        })
+        .collect();
+    f.render_widget(
+        Paragraph::new(lines).style(Style::default().bg(t.bg)),
+        inner,
+    );
 }
 
 fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     let t = &app.theme;
-    let line = Line::from(vec![
-        Span::styled("Enter", Style::default().fg(t.key_hint).bold()),
-        Span::raw(" promote selected process   "),
-        Span::styled("Shift+P", Style::default().fg(t.key_hint).bold()),
-        Span::raw(" promote all   "),
-        Span::styled("e", Style::default().fg(t.key_hint).bold()),
-        Span::raw(" export NDJSON   "),
-        Span::styled("✗ drift", Style::default().fg(t.status_error)),
-        Span::raw(" = outside allowlist (warns, never blocks)"),
-    ]);
-    let footer = Paragraph::new(line).block(
-        Block::default()
-            .borders(Borders::TOP)
-            .border_style(Style::default().fg(t.border)),
-    );
-    f.render_widget(footer, area);
-}
-
-/// Recent policy-drift warnings, newest first — shown on the same screen so
-/// the operator doesn't have to switch to the Timeline tab to see that a
-/// promoted process has drifted.
-fn render_warnings(f: &mut Frame, app: &App, area: Rect) {
-    let t = &app.theme;
-    let now = std::time::SystemTime::now();
-    let capacity = area.height.saturating_sub(2) as usize; // borders
-    let total = app.egress_profiler.recent_violation_count();
-
-    let mut lines: Vec<Line> = Vec::new();
-    for v in app.egress_profiler.recent_violations().take(capacity) {
-        lines.push(Line::from(vec![
+    if app.ui.egress_filter_input {
+        let line = Line::from(vec![
+            Span::styled(" / ", Style::default().fg(t.brand).bold()),
             Span::styled(
-                format!("{:>4} ago  ", fmt_age(v.when, now)),
+                app.ui.egress_filter_text.clone(),
+                Style::default().fg(t.text_primary),
+            ),
+            Span::styled("▏", Style::default().fg(t.brand).bold()),
+            Span::styled(
+                "    Enter apply   Esc cancel",
                 Style::default().fg(t.text_muted),
             ),
-            Span::styled("⚠ ", Style::default().fg(t.status_error)),
-            Span::styled(
-                v.process.clone(),
-                Style::default().fg(t.text_primary).bold(),
-            ),
-            Span::raw(" → "),
-            Span::styled(
-                format!("{}:{}", v.dest, v.port),
-                Style::default().fg(t.status_error),
-            ),
-            Span::styled(
-                format!("  ({})", v.reason),
-                Style::default().fg(t.text_muted),
-            ),
-        ]));
+        ]);
+        f.render_widget(Paragraph::new(line).style(Style::default().bg(t.bg)), area);
+        return;
     }
-
-    let title = format!(" ⚠ Active drift warnings ({total}) ");
-    let panel = Paragraph::new(lines).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(t.status_error))
-            .title(title),
+    let hint = |k: &'static str, label: &'static str| {
+        vec![
+            Span::styled(k, Style::default().fg(t.key_hint).bold()),
+            Span::raw(format!(" {label}   ")),
+        ]
+    };
+    let mut spans = vec![Span::raw(" ")];
+    spans.extend(hint("s", "sort"));
+    spans.extend(hint("/", "filter"));
+    spans.extend(hint("space", "fold"));
+    spans.extend(hint("d", "detail"));
+    spans.extend(hint("↵", "promote"));
+    spans.extend(hint("e", "export"));
+    // Teach the two glyphs that aren't self-evident, rather than restating
+    // that the linter never blocks — that belongs in the docs, not on every
+    // frame.
+    spans.push(Span::styled("~ asn", Style::default().fg(t.status_warn)));
+    spans.push(Span::styled(
+        " = whole-AS match   ",
+        Style::default().fg(t.text_muted),
+    ));
+    spans.push(Span::styled(
+        "— no rule",
+        Style::default().fg(t.status_warn),
+    ));
+    spans.push(Span::styled(
+        " = unchecked",
+        Style::default().fg(t.text_muted),
+    ));
+    f.render_widget(
+        Paragraph::new(Line::from(spans)).style(Style::default().bg(t.bg)),
+        area,
     );
-    f.render_widget(panel, area);
 }
 
-/// The process owning the selected row — flat index over the same ordering
-/// the table renders (processes alphabetical; any dest row selects its
-/// process, so per-dest ordering within a profile doesn't matter here).
-pub fn selected_process(app: &App) -> Option<String> {
-    let profiles = app.egress_profiler.snapshot();
-    let selected = app.ui.scroll.egress_scroll;
-    let mut idx = 0usize;
-    for profile in &profiles {
-        let n = profile.dests.len();
-        if selected < idx + n {
-            return Some(profile.process.clone());
-        }
-        idx += n;
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `count` is ticks-since-first-seen, i.e. seconds. Rendering it raw was
+    /// the bug: `31427` reads as a request count but means 8.7 hours.
+    #[test]
+    fn dwell_reads_as_a_duration_not_a_count() {
+        assert_eq!(dwell(0), "—");
+        assert_eq!(dwell(45), "45s");
+        assert_eq!(dwell(600), "10m");
+        assert_eq!(dwell(31_427), "8.7h");
+        assert_eq!(dwell(200_000), "2.3d");
     }
-    // Selection clamped past the end (list shrank) → last process.
-    profiles.last().map(|p| p.process.clone())
-}
 
-/// Compact age like `34s`, `5m`, `3h`, `2d`.
-fn fmt_age(t: std::time::SystemTime, now: std::time::SystemTime) -> String {
-    let secs = now.duration_since(t).map(|d| d.as_secs()).unwrap_or(0);
-    match secs {
-        0..=59 => format!("{secs}s"),
-        60..=3599 => format!("{}m", secs / 60),
-        3600..=86399 => format!("{}h", secs / 3600),
-        _ => format!("{}d", secs / 86400),
+    /// No capture means no rates, which means no bytes. Showing "0 B" would
+    /// assert that nothing was sent; "—" says we don't know.
+    #[test]
+    fn zero_volume_renders_as_unknown_not_zero() {
+        assert_eq!(vol(0), "—");
+        assert_eq!(vol(1536), "2 KB");
+    }
+
+    #[test]
+    fn human_bytes_reaches_gigabytes() {
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(2 * 1024 * 1024), "2.0 MB");
+        assert_eq!(human_bytes(3 * 1024 * 1024 * 1024), "3.0 GB");
+    }
+
+    #[test]
+    fn spark_scales_to_its_own_maximum() {
+        let s = spark(&[0, 50, 100], 7);
+        assert_eq!(s.chars().count(), 3);
+        assert_eq!(s.chars().next().unwrap(), '▁');
+        assert_eq!(s.chars().last().unwrap(), '█');
+    }
+
+    /// An all-zero series is a real answer — a flat floor — not an empty
+    /// cell, which would look like missing data.
+    #[test]
+    fn spark_renders_a_flat_floor_for_all_zero() {
+        assert_eq!(spark(&[0, 0, 0], 7), "▁▁▁");
+        assert_eq!(spark(&[], 7), "");
+    }
+
+    #[test]
+    fn spark_shows_only_the_most_recent_window() {
+        let s = spark(&[1, 2, 3, 4, 5, 6, 7, 8, 9], 4);
+        assert_eq!(s.chars().count(), 4, "oldest samples are dropped");
+    }
+
+    #[test]
+    fn truncate_marks_elision() {
+        assert_eq!(truncate("short", 9), "short");
+        assert_eq!(truncate("Microsoft Corporation", 9), "Microsof…");
     }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -196,8 +196,13 @@ fn build_help_lines(theme: &Theme) -> Vec<Line<'static>> {
     lines.push(key_line(theme, "Esc", "Clear active filter"));
     lines.push(key_line(
         theme,
+        "space",
+        "Fold/expand the group under the cursor (grouped modes)",
+    ));
+    lines.push(key_line(
+        theme,
         "Enter",
-        "Jump to Packets tab with filter for selected connection",
+        "Jump to Packets tab with filter for selected connection; on a group row, fold it",
     ));
     lines.push(key_line(
         theme,

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -337,6 +337,17 @@ fn build_help_lines(theme: &Theme) -> Vec<Line<'static>> {
         "— no rule",
         "Process undeclared — nothing was checked",
     ));
+    lines.push(key_line(
+        theme,
+        "✗ undeclared",
+        "No rule, under strict = true — the absence is the finding",
+    ));
+    lines.push(Line::raw(""));
+    lines.push(key_line(
+        theme,
+        "strict = true",
+        "Set in egress-policy.toml to warn on any undeclared process",
+    ));
     lines.push(Line::raw(""));
 
     // DISPLAY FILTER SYNTAX

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -311,9 +311,14 @@ fn build_help_lines(theme: &Theme) -> Vec<Line<'static>> {
     lines.push(key_line(
         theme,
         "Enter",
-        "Promote selected process into policy",
+        "Add selected process to policy (from its observed baseline)",
     ));
-    lines.push(key_line(theme, "P (shift)", "Promote every process"));
+    lines.push(key_line(theme, "P (shift)", "Add every observed process"));
+    lines.push(key_line(
+        theme,
+        "x / Del",
+        "Remove selected process from policy (confirm with y)",
+    ));
     lines.push(key_line(theme, "e", "Export baseline to NDJSON"));
     lines.push(Line::raw(""));
     lines.push(key_line(

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -199,6 +199,7 @@ fn build_help_lines(theme: &Theme) -> Vec<Line<'static>> {
         "space",
         "Fold/expand the group under the cursor (grouped modes)",
     ));
+    lines.push(key_line(theme, "z", "Fold/expand every group"));
     lines.push(key_line(
         theme,
         "Enter",
@@ -324,6 +325,12 @@ fn build_help_lines(theme: &Theme) -> Vec<Line<'static>> {
         "x / Del",
         "Remove selected process from policy (confirm with y)",
     ));
+    lines.push(key_line(
+        theme,
+        "space",
+        "Fold/expand the process under the cursor",
+    ));
+    lines.push(key_line(theme, "z", "Fold/expand every process"));
     lines.push(key_line(theme, "e", "Export baseline to NDJSON"));
     lines.push(Line::raw(""));
     lines.push(key_line(

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -289,6 +289,56 @@ fn build_help_lines(theme: &Theme) -> Vec<Line<'static>> {
     lines.push(key_line(theme, "e", "Export connections to JSON + CSV"));
     lines.push(Line::raw(""));
 
+    // EGRESS
+    lines.push(section_header(theme, "EGRESS (Tab 0)"));
+    lines.push(key_line(
+        theme,
+        "↑↓ / j/k",
+        "Move cursor (click also selects)",
+    ));
+    lines.push(key_line(
+        theme,
+        "space",
+        "Fold / unfold a process (or click its ▼)",
+    ));
+    lines.push(key_line(
+        theme,
+        "s",
+        "Cycle sort (volume / active / process / last seen / risk)",
+    ));
+    lines.push(key_line(theme, "/", "Filter by process or destination"));
+    lines.push(key_line(theme, "d", "Toggle destination detail pane"));
+    lines.push(key_line(
+        theme,
+        "Enter",
+        "Promote selected process into policy",
+    ));
+    lines.push(key_line(theme, "P (shift)", "Promote every process"));
+    lines.push(key_line(theme, "e", "Export baseline to NDJSON"));
+    lines.push(Line::raw(""));
+    lines.push(key_line(
+        theme,
+        "✓ sni / ✓ ip",
+        "Matched a declared name or address",
+    ));
+    lines.push(key_line(
+        theme,
+        "~ asn",
+        "Admitted by autonomous system — broad, not one endpoint",
+    ));
+    lines.push(key_line(
+        theme,
+        "? ech",
+        "Name encrypted (ECH) — cannot judge",
+    ));
+    lines.push(key_line(theme, "✗ drift", "Outside the allowlist"));
+    lines.push(key_line(
+        theme,
+        "— no rule",
+        "Process undeclared — nothing was checked",
+    ));
+    lines.push(Line::raw(""));
+
     // DISPLAY FILTER SYNTAX
     lines.push(section_header(theme, "DISPLAY FILTER SYNTAX"));
     lines.push(key_line(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,4 +13,5 @@ pub mod sort_picker;
 pub mod stats;
 pub mod timeline;
 pub mod topology;
+pub mod tree;
 pub mod widgets;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -5,7 +5,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph},
 };
 
-pub const SETTINGS_COUNT: usize = 18;
+pub const SETTINGS_COUNT: usize = 19;
 
 pub const TAB_NAMES: &[&str] = &[
     "dashboard",
@@ -39,6 +39,7 @@ pub mod cursor {
     pub const GRAPH_STYLE: usize = 15;
     pub const GRAPH_FADE: usize = 16;
     pub const SANDBOX: usize = 17;
+    pub const GROUPS_COLLAPSED: usize = 18;
 }
 
 struct SettingRow {
@@ -57,6 +58,7 @@ fn is_cycle_through(cursor: usize) -> bool {
             | cursor::GRAPH_STYLE
             | cursor::GRAPH_FADE
             | cursor::SANDBOX
+            | cursor::GROUPS_COLLAPSED
     )
 }
 
@@ -149,6 +151,15 @@ fn build_rows(cfg: &NetwatchConfig) -> Vec<SettingRow> {
         SettingRow {
             label: "Sandbox",
             value: cfg.sandbox.clone(),
+        },
+        SettingRow {
+            label: "Groups Start Folded",
+            value: if cfg.groups_start_collapsed {
+                "on"
+            } else {
+                "off"
+            }
+            .into(),
         },
     ]
 }
@@ -352,6 +363,12 @@ pub fn get_edit_value(cfg: &NetwatchConfig, cursor: usize) -> String {
         15 => cfg.graph_style.clone(),
         16 => if cfg.graph_fade { "on" } else { "off" }.into(),
         17 => cfg.sandbox.clone(),
+        18 => if cfg.groups_start_collapsed {
+            "on"
+        } else {
+            "off"
+        }
+        .into(),
         _ => String::new(),
     }
 }
@@ -485,6 +502,14 @@ pub fn apply_edit(cfg: &mut NetwatchConfig, cursor: usize, value: &str) -> Resul
                 }
                 _ => Err("Use on / strict / off".into()),
             }
+        }
+        18 => {
+            match value.to_lowercase().as_str() {
+                "on" | "true" | "yes" | "1" => cfg.groups_start_collapsed = true,
+                "off" | "false" | "no" | "0" => cfg.groups_start_collapsed = false,
+                _ => return Err("Use on / off".into()),
+            }
+            Ok(())
         }
         _ => Err("Unknown setting".into()),
     }

--- a/src/ui/tree.rs
+++ b/src/ui/tree.rs
@@ -1,0 +1,212 @@
+//! Shared machinery for the grouped-tree tables (Egress, Connections).
+//!
+//! Several screens hold the same shape of data — a set of rows that all carry
+//! a process name, or a host — and rendering that as a flat table spends a
+//! large fraction of the widest column repeating the string above it. The
+//! Egress tab replaced its flat table with a tree (one parent row per group,
+//! carrying a rollup, with foldable children) and this module is that pattern
+//! pulled out so a second screen doesn't reimplement it.
+//!
+//! Deliberately *not* shared: rendering. The two screens draw very
+//! differently — Egress builds a `ratatui::Table`, Connections paints each row
+//! at explicit column offsets — and forcing one renderer on both would be a
+//! worse fit than the duplication it removes. What is shared is the part that
+//! was actually error-prone: grouping, fold state, flattening to a numbered
+//! row list, and mapping a screen position back to a row. That last one is
+//! where issue #28 lived (clicks resolved against the *previous selection*
+//! rather than the visible window), and it is worth having exactly once.
+
+use std::collections::HashSet;
+
+/// A group of children sharing a key, plus whatever summary the screen wants
+/// on the parent row.
+///
+/// `rollup` is computed by the caller rather than here: "sum the bytes" means
+/// something different on every screen, and a trait to abstract it would be
+/// more machinery than the two implementations justify.
+pub struct Group<R, C> {
+    /// The value rows were grouped by — a process name, a remote host. Also
+    /// the fold-state identity, so it must be stable frame to frame.
+    pub key: String,
+    pub rollup: R,
+    pub children: Vec<C>,
+}
+
+/// One line of a rendered tree: a group header, or one of its children.
+pub enum Row<'a, R, C> {
+    Parent {
+        group: &'a Group<R, C>,
+        collapsed: bool,
+    },
+    Child {
+        group: &'a Group<R, C>,
+        item: &'a C,
+    },
+}
+
+impl<R, C> Row<'_, R, C> {
+    /// The group this row belongs to — the same answer for a parent and for
+    /// any of its children, which is what makes "fold the thing under the
+    /// cursor" work from a child row.
+    pub fn key(&self) -> &str {
+        match self {
+            Row::Parent { group, .. } | Row::Child { group, .. } => &group.key,
+        }
+    }
+
+    pub fn is_parent(&self) -> bool {
+        matches!(self, Row::Parent { .. })
+    }
+}
+
+/// Bucket items by key, preserving first-seen order within each group.
+///
+/// Order of the groups themselves is left to the caller: every screen wants
+/// to sort them by its own rollup (volume, risk, rate), and sorting here
+/// would only be overwritten.
+pub fn group_by<T, K>(items: impl IntoIterator<Item = T>, key: K) -> Vec<(String, Vec<T>)>
+where
+    K: Fn(&T) -> String,
+{
+    let mut order: Vec<String> = Vec::new();
+    let mut buckets: std::collections::HashMap<String, Vec<T>> = std::collections::HashMap::new();
+    for item in items {
+        let k = key(&item);
+        buckets.entry(k.clone()).or_insert_with(|| {
+            order.push(k.clone());
+            Vec::new()
+        });
+        buckets.get_mut(&k).expect("just inserted").push(item);
+    }
+    order
+        .into_iter()
+        .map(|k| {
+            let v = buckets.remove(&k).unwrap_or_default();
+            (k, v)
+        })
+        .collect()
+}
+
+/// Flatten groups into the visible row list, honouring fold state.
+///
+/// This is the single definition of "what is on screen, in order". Both the
+/// renderer and the input handlers go through it, so a click, an arrow key
+/// and a drawn row can never disagree about what row 7 is.
+pub fn flatten<'a, R, C>(
+    groups: &'a [Group<R, C>],
+    collapsed: &HashSet<String>,
+) -> Vec<Row<'a, R, C>> {
+    let mut rows = Vec::new();
+    for group in groups {
+        let is_collapsed = collapsed.contains(&group.key);
+        rows.push(Row::Parent {
+            group,
+            collapsed: is_collapsed,
+        });
+        if !is_collapsed {
+            for item in &group.children {
+                rows.push(Row::Child { group, item });
+            }
+        }
+    }
+    rows
+}
+
+/// Toggle a group's fold state. Returns true if it is now collapsed.
+pub fn toggle(collapsed: &mut HashSet<String>, key: &str) -> bool {
+    if collapsed.remove(key) {
+        false
+    } else {
+        collapsed.insert(key.to_string());
+        true
+    }
+}
+
+/// First visible row index given the selection, so the cursor stays on screen.
+///
+/// Keeps the selection centred once it leaves the first page, rather than
+/// scrolling one row at a time from the top.
+pub fn window_top(selected: usize, total: usize, visible: usize) -> usize {
+    if selected < visible {
+        return 0;
+    }
+    selected
+        .saturating_sub(visible / 2)
+        .min(total.saturating_sub(visible))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn groups() -> Vec<Group<usize, &'static str>> {
+        vec![
+            Group {
+                key: "curl".into(),
+                rollup: 2,
+                children: vec!["a", "b"],
+            },
+            Group {
+                key: "gh".into(),
+                rollup: 1,
+                children: vec!["c"],
+            },
+        ]
+    }
+
+    #[test]
+    fn flatten_emits_a_parent_then_its_children() {
+        let g = groups();
+        let rows = flatten(&g, &HashSet::new());
+        assert_eq!(rows.len(), 5);
+        assert!(rows[0].is_parent());
+        assert_eq!(rows[0].key(), "curl");
+        assert!(!rows[1].is_parent());
+        assert_eq!(rows[1].key(), "curl", "a child reports its parent's key");
+        assert!(rows[3].is_parent());
+        assert_eq!(rows[3].key(), "gh");
+    }
+
+    /// A collapsed group keeps its header — folding hides detail, it never
+    /// hides the existence of the thing.
+    #[test]
+    fn collapsing_hides_children_but_never_the_parent() {
+        let g = groups();
+        let mut collapsed = HashSet::new();
+        collapsed.insert("curl".to_string());
+        let rows = flatten(&g, &collapsed);
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().all(|r| r.is_parent() || r.key() == "gh"));
+        assert!(rows[0].is_parent() && rows[0].key() == "curl");
+    }
+
+    #[test]
+    fn toggle_round_trips() {
+        let mut collapsed = HashSet::new();
+        assert!(toggle(&mut collapsed, "curl"));
+        assert!(collapsed.contains("curl"));
+        assert!(!toggle(&mut collapsed, "curl"));
+        assert!(collapsed.is_empty());
+    }
+
+    #[test]
+    fn group_by_preserves_first_seen_order_and_membership() {
+        let items = vec![("a", 1), ("b", 2), ("a", 3)];
+        let g = group_by(items, |(k, _)| k.to_string());
+        assert_eq!(g.len(), 2);
+        assert_eq!(g[0].0, "a", "first key seen comes first");
+        assert_eq!(g[0].1, vec![("a", 1), ("a", 3)]);
+        assert_eq!(g[1].0, "b");
+    }
+
+    /// The window must never scroll past the end, or the last page renders
+    /// blank rows below the final item.
+    #[test]
+    fn window_top_clamps_to_the_last_page() {
+        assert_eq!(window_top(0, 100, 10), 0);
+        assert_eq!(window_top(5, 100, 10), 0, "first page never scrolls");
+        assert_eq!(window_top(50, 100, 10), 45, "selection stays centred");
+        assert_eq!(window_top(99, 100, 10), 90, "clamped to the last page");
+        assert_eq!(window_top(5, 3, 10), 0, "fewer items than the window");
+    }
+}

--- a/src/ui/tree.rs
+++ b/src/ui/tree.rs
@@ -92,13 +92,10 @@ where
 /// This is the single definition of "what is on screen, in order". Both the
 /// renderer and the input handlers go through it, so a click, an arrow key
 /// and a drawn row can never disagree about what row 7 is.
-pub fn flatten<'a, R, C>(
-    groups: &'a [Group<R, C>],
-    collapsed: &HashSet<String>,
-) -> Vec<Row<'a, R, C>> {
+pub fn flatten<'a, R, C>(groups: &'a [Group<R, C>], fold: &FoldState) -> Vec<Row<'a, R, C>> {
     let mut rows = Vec::new();
     for group in groups {
-        let is_collapsed = collapsed.contains(&group.key);
+        let is_collapsed = fold.is_collapsed(&group.key);
         rows.push(Row::Parent {
             group,
             collapsed: is_collapsed,
@@ -112,13 +109,72 @@ pub fn flatten<'a, R, C>(
     rows
 }
 
-/// Toggle a group's fold state. Returns true if it is now collapsed.
-pub fn toggle(collapsed: &mut HashSet<String>, key: &str) -> bool {
-    if collapsed.remove(key) {
-        false
-    } else {
-        collapsed.insert(key.to_string());
-        true
+/// Which groups are folded.
+///
+/// Stored as a default plus the keys that differ from it, rather than a set of
+/// collapsed names. The distinction matters because groups appear and vanish
+/// while you are looking at the screen: with a plain collapsed-set, a process
+/// that starts talking *after* you collapsed everything would arrive expanded,
+/// and "fold all" would quietly come undone one row at a time. Here a new
+/// group inherits the default, so the screen stays as the user arranged it.
+///
+/// It also makes fold-all and expand-all exact rather than best-effort — they
+/// set the default and drop the exceptions, so they cannot leave a straggler.
+#[derive(Debug, Clone, Default)]
+pub struct FoldState {
+    /// What a group does when nothing specific has been said about it.
+    default_collapsed: bool,
+    /// Keys whose state is the opposite of `default_collapsed`.
+    exceptions: HashSet<String>,
+}
+
+impl FoldState {
+    /// A fold state where groups start collapsed (or not), per config.
+    pub fn new(default_collapsed: bool) -> Self {
+        Self {
+            default_collapsed,
+            exceptions: HashSet::new(),
+        }
+    }
+
+    pub fn is_collapsed(&self, key: &str) -> bool {
+        self.default_collapsed != self.exceptions.contains(key)
+    }
+
+    /// Toggle one group. Returns true if it is now collapsed.
+    pub fn toggle(&mut self, key: &str) -> bool {
+        if !self.exceptions.remove(key) {
+            self.exceptions.insert(key.to_string());
+        }
+        self.is_collapsed(key)
+    }
+
+    pub fn collapse_all(&mut self) {
+        self.default_collapsed = true;
+        self.exceptions.clear();
+    }
+
+    pub fn expand_all(&mut self) {
+        self.default_collapsed = false;
+        self.exceptions.clear();
+    }
+
+    /// Whether every group is currently collapsed — what a single fold-all
+    /// key needs in order to decide which way to go.
+    pub fn all_collapsed(&self) -> bool {
+        self.default_collapsed && self.exceptions.is_empty()
+    }
+
+    /// Collapse everything if anything is open, otherwise open everything.
+    /// Returns true if the result is collapsed.
+    pub fn toggle_all(&mut self) -> bool {
+        if self.all_collapsed() {
+            self.expand_all();
+            false
+        } else {
+            self.collapse_all();
+            true
+        }
     }
 }
 
@@ -157,7 +213,7 @@ mod tests {
     #[test]
     fn flatten_emits_a_parent_then_its_children() {
         let g = groups();
-        let rows = flatten(&g, &HashSet::new());
+        let rows = flatten(&g, &FoldState::new(false));
         assert_eq!(rows.len(), 5);
         assert!(rows[0].is_parent());
         assert_eq!(rows[0].key(), "curl");
@@ -172,9 +228,9 @@ mod tests {
     #[test]
     fn collapsing_hides_children_but_never_the_parent() {
         let g = groups();
-        let mut collapsed = HashSet::new();
-        collapsed.insert("curl".to_string());
-        let rows = flatten(&g, &collapsed);
+        let mut fold = FoldState::new(false);
+        fold.toggle("curl");
+        let rows = flatten(&g, &fold);
         assert_eq!(rows.len(), 3);
         assert!(rows.iter().all(|r| r.is_parent() || r.key() == "gh"));
         assert!(rows[0].is_parent() && rows[0].key() == "curl");
@@ -182,11 +238,70 @@ mod tests {
 
     #[test]
     fn toggle_round_trips() {
-        let mut collapsed = HashSet::new();
-        assert!(toggle(&mut collapsed, "curl"));
-        assert!(collapsed.contains("curl"));
-        assert!(!toggle(&mut collapsed, "curl"));
-        assert!(collapsed.is_empty());
+        let mut fold = FoldState::new(false);
+        assert!(fold.toggle("curl"));
+        assert!(fold.is_collapsed("curl"));
+        assert!(!fold.toggle("curl"));
+        assert!(!fold.is_collapsed("curl"));
+    }
+
+    /// Starting collapsed must mean *every* group, including ones that did
+    /// not exist yet. A collapsed-set model gets this wrong: a process that
+    /// starts talking after you folded everything arrives expanded, and the
+    /// screen you arranged unpicks itself one row at a time.
+    #[test]
+    fn a_group_first_seen_later_inherits_the_default() {
+        let fold = FoldState::new(true);
+        assert!(fold.is_collapsed("never-seen-before"));
+        let open = FoldState::new(false);
+        assert!(!open.is_collapsed("never-seen-before"));
+    }
+
+    /// Toggling one group under a collapsed default expands just that one,
+    /// and leaves everything else — present and future — folded.
+    #[test]
+    fn an_exception_does_not_disturb_the_default() {
+        let mut fold = FoldState::new(true);
+        assert!(!fold.toggle("curl"), "toggling a collapsed group opens it");
+        assert!(!fold.is_collapsed("curl"));
+        assert!(fold.is_collapsed("gh"));
+        assert!(fold.is_collapsed("appears-later"));
+        assert!(!fold.all_collapsed(), "one group is open");
+    }
+
+    /// Fold-all and expand-all must be exact, not best-effort — they drop the
+    /// exceptions rather than trying to enumerate what is currently open.
+    #[test]
+    fn fold_all_leaves_no_stragglers() {
+        let mut fold = FoldState::new(false);
+        fold.toggle("curl");
+        fold.toggle("gh");
+        fold.collapse_all();
+        assert!(fold.all_collapsed());
+        for k in ["curl", "gh", "brand-new"] {
+            assert!(fold.is_collapsed(k), "{k} should be folded");
+        }
+
+        fold.expand_all();
+        for k in ["curl", "gh", "brand-new"] {
+            assert!(!fold.is_collapsed(k), "{k} should be open");
+        }
+    }
+
+    #[test]
+    fn toggle_all_flips_between_fully_folded_and_fully_open() {
+        let mut fold = FoldState::new(false);
+        assert!(fold.toggle_all(), "anything open → fold everything");
+        assert!(fold.all_collapsed());
+        assert!(!fold.toggle_all(), "all folded → open everything");
+        assert!(!fold.is_collapsed("curl"));
+
+        // A single open group is still "not all collapsed", so the next
+        // toggle folds rather than expanding a screen that is mostly folded.
+        fold.collapse_all();
+        fold.toggle("curl");
+        assert!(fold.toggle_all());
+        assert!(fold.all_collapsed());
     }
 
     #[test]


### PR DESCRIPTION
Rebuilds the Egress tab around what an egress screen is for, fixes the two critical findings in the policy model underneath it, and brings the grouped tree to Connections on shared machinery.

Five commits, each self-contained. Rebased on `main` post-v0.28.0.

---

## 1. Egress: byte accounting, grouped tree, verdict vocabulary

**`Seen` was a duration wearing a counter's clothes.** `observe` runs once per ~1 s tick and did `count += 1` per tick a flow was present — so `31427` meant *open for 8.7 hours*, not 31k requests. A number meaning something other than its label, on the screen that justifies a policy decision. Now rendered as a duration, labelled **Active**.

**There was no volume anywhere.** An egress-forensics tab could not answer *how much data left this machine*, while `Connection` already carried `rx_rate`/`tx_rate`, computed every tick and thrown away. Destinations now accumulate `bytes_out`/`bytes_in` plus a bounded per-tick series for the sparkline.

**The verdict vocabulary** is the change that carries the most meaning. `dest_allowed`'s bool collapsed "matched an exact hostname" and "matched an entire autonomous system" into one `✓ ok` — which is how a promoted rule could admit all of Google Cloud and still render clean.

| verdict | meaning |
|---|---|
| `✓ sni` / `✓ ip` | matched a declared name or address — precise |
| `~ asn` | admitted by autonomous system — **broad** |
| `? ech` | name encrypted — cannot judge |
| `✗ drift` | outside the allowlist |
| `— no rule` | process undeclared — **nothing was checked** |

Plus `s` sort (including **risk**), `/` filter, `space` fold, `d` detail pane, and mouse. Click mapping goes through the same window the renderer computes rather than `scroll + row` — that was issue #28 on Connections and the bug would have been identical here.

---

## 2. Strict mode, and promotion stops widening to an ASN

The two criticals from the policy analysis. Both are about the same failure mode: a green screen that means less than it appears to.

**Undeclared processes were never checked.** `check_policy` returned early when a process had no rule, so a policy covering all 24 processes on a machine said nothing about the 25th — and a new binary is precisely what a compromise introduces. `strict = true` in the policy file opts into treating the policy as complete, making the absence of a rule a finding. Off by default. It lives in the policy file rather than `config.toml` because it is a claim about *that policy* and is meaningless without one. A process must persist three observation ticks before being reported, which suppresses a fork storm of one-tick build tooling without suppressing anything that could move volume.

**Promotion silently allowlisted whole autonomous systems.** `rule_from_profile` wrote an `allow_asn` entry for any destination without an SNI, and `violation` admits on *any* dimension — so one nameless Google flow at promote time admitted every host Google operates, for that process, forever, rendering `✓ ok`. Promotion now takes identity from the SNI or the address; ASN is reached only when a destination has neither, and only if the org actually names someone. `Unassigned` is the geo DB's *failure* label, so promoting it admitted every destination whose lookup failed. Hand-written ASN rules still match — the file should do what it says — but nothing generates one.

Measured on a real 25-process / 149-destination baseline, old code vs new on the same file:

| | rules ASN-wide | ASN entries | (dest,port) pairs admitted |
|---|---:|---:|---:|
| before | 12 of 25 | 21 | 282 |
| after | **0** | **0** | 245 |

Two of the twelve were `Unassigned`. `Google Chrome Helper` had acquired `Google LLC` — the `evil.appspot.com` case exactly. With the promoted policy loaded, 145 of 149 destinations now read as precise `✓ sni`/`✓ ip`.

`Verdict::Undeclared` is distinct from `NoRule` — checked-and-unexpected versus unchecked — and ranks above `Drift` for attention. The NDJSON export emits `undeclared` as its own verdict rather than folding it into `drift`; nothing was compared, and saying drift would overstate what the linter knows.

---

## 3. Add and remove processes from the policy

Promotion could only ever grow an allowlist — `merge_rules_into_policy_file` is additive by design. But withdrawing coverage is an ordinary part of tuning a policy, and dropping to a text editor to do it was a strange gap on the tab whose job is authoring that file.

`remove_rules_from_policy_file` deletes named rules through `toml_edit`, preserving comments, unrelated rules, the top-level `strict` flag and 0600 permissions, and refusing an unparseable file for the same reason promotion does.

A comment immediately above a rule goes with it — it documents that rule. The exception is the file's leading comment block, which `toml_edit` stores as the first table's prefix: removing the only rule emptied the file completely, taking the header explaining `strict` and promotion with it. **Found by driving the binary, not by reading the code.** That block is now restored explicitly.

Bound to `x` / `Del`, ahead of the unguarded sort arms. Removal is the one destructive action here, so it confirms, and the prompt names what cannot be undone. Only `y` confirms — `Enter` deliberately does not, since it is the add-to-policy key on the same tab, and one keystroke meaning both "add" and "delete" is how people delete things they meant to keep.

The footer is now two lines: navigation, then the actions that write to the policy file, under their real names. "Promote" is jargon for "add to policy".

Two more things this surfaced: `✗ undeclared` truncated to `✗ undeclare` in an 11-wide column, and `export_status` renders in the shared header slot that the tab bar consumes at any ordinary width — so on this tab the outcome of a policy edit was never visible, and pressing `x` on a process with no rule looked identical to a dead key.

---

## 4. Connections: the same tree, on shared machinery

`group: process` and `group: remote` were sort orders wearing the word "group". Rows clustered, but the key was still restated on every one, so the tab spent its widest column repeating the string above it: `claude` down eleven consecutive rows, `ControlCenter` on four identical `*:*` LISTEN rows, and the process column so starved of width it rendered `Google Chrome…` and `Code Helper (…`.

They are now actual trees. The same screen reads as 13 processes; `Google Chrome Helper` fits.

The rollup answers each column's question at group scale rather than inventing a layout: PROTO stays empty (a rollup has no protocol, and a count under that header would be a lie), REMOTE carries `18 conns · 1 pid`, STATE gives the dominant state and — when mixed — how many share it. It surfaces retransmits from any child, because a rollup that hides a problem visible on an expanded row is worse than no rollup: the user stops expanding.

`ui/tree.rs` holds what was actually error-prone: grouping, fold state, flattening to a numbered row list, the window computation. **Not rendering** — Egress builds a `ratatui::Table` and Connections paints at explicit column offsets, and forcing one renderer on both would be a worse fit than the duplication it removes.

**The part that could have gone quietly wrong:** row indices now include headers, so anything resolving "the selected connection" by indexing the *connection* list would act on the wrong flow — issue #28 with a new cause. Traceroute, whois, drill-to-packets, the detail strip, scroll clamping and click mapping all route through `selected_connection`, which returns `None` on a header rather than the first child beneath it. A test pins that.

Not converted, and why: Processes already has a per-process drill-in pane; Timeline is chronological and grouping would destroy its axis; Packets has no process attribution; Dashboard already aggregates to `(process, host)` and is a glanceable summary, not a navigable table.

---

## 5. Groups start folded, and `z` folds/expands all

The tree made the overview possible; folded-by-default makes it the thing you land on. Connections opens as 13 processes instead of 63 rows, Egress as 25 processes instead of 182 destinations.

A `HashSet` of collapsed keys cannot express "collapsed by default". Groups appear and vanish while you are looking at the screen, so a process that starts talking *after* you folded everything would arrive expanded, and a folded screen would unpick itself one row at a time. `tree::FoldState` stores a default plus the keys that differ from it, so a new group inherits the default. It also makes fold-all exact rather than best-effort — it sets the default and drops the exceptions, so it cannot leave a straggler.

`groups_start_collapsed`, default true, in `config.toml` and on the settings screen as "Groups Start Folded". Toggling it applies to the live screens immediately, not just next launch: a preference whose effect you cannot see while the tab behind the overlay visibly disagrees with it reads as a broken toggle.

**Defaulting to true is a behaviour change for existing users**, and a deliberate one — the flat tables were the problem this whole line of work started from. The setting is there for anyone who wants the old shape back.

---

## Testing

**642 pass**, fmt clean, clippy **57 — exactly `main`'s own baseline**, verified by building `origin/main` in a scratch worktree rather than trusting a remembered number.

Beyond unit tests, each change was driven against the real binary in a pty with a terminal emulator, using a sandboxed `HOME` holding a real 25-process baseline. That is what caught: the emptied policy header, the truncated verdict, the invisible status line, UDP's empty state rendering as a bare `11/13`, the selected parent losing its fold chevron, and a panel title reading `13 in 13 process process`. None of those are visible from the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EJJzKy2k1HBbhA3sAGCTP
