### PR TITLE
netwatch v0.30.4: Windows capture finds the right adapter (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to NetWatch will be documented in this file.
 
 ## [Unreleased]
 
+## [0.30.4] - 2026-09-09
+
+### Fixed
+- **Windows: capture opened the wrong adapter, or none, on Hyper-V hosts**
+  ([#51](https://github.com/matthart1983/netwatch/issues/51)). The friendly
+  name ipconfig shows was matched as a *substring of Npcap's description*,
+  which is the driver's name, not the adapter's. "Ethernet" therefore landed on
+  the first "Hyper-V Virtual Ethernet Adapter" Npcap listed — the WSL switch,
+  which sees nothing but mDNS — and "vEthernet (WSL)" matched nothing and was
+  handed to Npcap verbatim, failing with "The system cannot find the file
+  specified". Adapters are now matched by interface GUID from `Get-NetAdapter`,
+  which is what Npcap's `\Device\NPF_{GUID}` name carries, with the adapter's
+  IPv4 address as the fallback where PowerShell is unavailable. A name that
+  matches no adapter says so instead of surfacing the raw open error. The
+  lookup runs on the capture thread, so PowerShell start-up no longer sits in
+  the key handler.
+- **Windows: the default capture interface honours the default route.** The
+  route-based pick from #43 only existed on Linux and macOS; Windows fell
+  through to the first UP adapter with an IPv4, which on a Hyper-V host is
+  often `vEthernet (Default Switch)`.
+
 ## [0.30.3] - 2026-09-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "netwatch-tui"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "anyhow",
  "brotli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netwatch-tui"
-version = "0.30.3"
+version = "0.30.4"
 edition = "2021"
 authors = ["Matt Hartley <matthew.t.hartley@gmail.com>"]
 description = "Real-time network diagnostics in your terminal. One command, zero config, instant visibility."

--- a/src/collectors/packets/mod.rs
+++ b/src/collectors/packets/mod.rs
@@ -1335,10 +1335,22 @@ impl PacketCollector {
         let dns = self.dns_cache.clone();
         let stats = Arc::clone(&self.stats);
         stats.reset();
-        let iface = resolve_device_name(interface);
+        let interface = interface.to_string();
         let bpf = bpf_filter.map(|s| s.to_string());
 
         self.handle = Some(thread::spawn(move || {
+            // Resolved on the capture thread: on Windows this shells out to
+            // PowerShell, which must not stall the key handler.
+            let iface = match resolve_device_name(&interface) {
+                Ok(name) => name,
+                Err(msg) => {
+                    tracing::error!(target: "netwatch::capture", interface = %interface, error = %msg, "device resolution failed");
+                    *crate::app::safe_lock(&error, "packets::capture_resolve_error") = Some(msg);
+                    capturing.store(false, Ordering::SeqCst);
+                    return;
+                }
+            };
+
             // Try with promiscuous mode first, fall back to non-promiscuous
             // (some interfaces like loopback don't support promisc on macOS)
             let cap = pcap::Capture::from_device(iface.as_str())
@@ -2721,41 +2733,57 @@ pub use pcap_export::export_pcap;
 mod filter;
 pub use filter::{matches_packet, parse_filter, FilterExpr};
 
-/// On Windows, pcap needs the `\Device\NPF_{GUID}` name rather than the
-/// friendly name (e.g. "Ethernet" or "Wi-Fi") that ipconfig reports.
-/// This maps friendly names to the pcap device name by matching descriptions.
-/// On non-Windows platforms this is a no-op.
-fn resolve_device_name(friendly: &str) -> String {
+/// The device name pcap opens for a user-facing interface name.
+///
+/// On Windows pcap needs `\Device\NPF_{GUID}`, not the friendly name ipconfig
+/// reports ("Ethernet", "vEthernet (WSL)"). The matching lives in
+/// `platform::npcap_device` — by the adapter's GUID from `Get-NetAdapter`, then
+/// by its IPv4 address, never by description substring (issue #51). Elsewhere
+/// the name is already the device name.
+fn resolve_device_name(friendly: &str) -> Result<String, String> {
     #[cfg(not(target_os = "windows"))]
     {
-        friendly.to_string()
+        Ok(friendly.to_string())
     }
 
     #[cfg(target_os = "windows")]
     {
-        // If it already looks like an NPF path, use as-is.
+        use crate::platform::npcap_device::{guid_for, match_npcap_device, PcapDevice};
+
         if friendly.starts_with("\\Device\\") || friendly.starts_with("\\\\") {
-            return friendly.to_string();
+            return Ok(friendly.to_string());
         }
 
-        let devices = match pcap::Device::list() {
-            Ok(d) => d,
-            Err(_) => return friendly.to_string(),
-        };
+        let devices: Vec<PcapDevice> = pcap::Device::list()
+            .map_err(|e| format!("Npcap adapter list failed: {e}"))?
+            .into_iter()
+            .map(|d| PcapDevice {
+                name: d.name,
+                desc: d.desc,
+                addrs: d.addresses.into_iter().map(|a| a.addr).collect(),
+            })
+            .collect();
 
-        let friendly_lower = friendly.to_lowercase();
-
-        // Match against the device description (which contains the friendly name).
-        for dev in &devices {
-            if let Some(ref desc) = dev.desc {
-                if desc.to_lowercase().contains(&friendly_lower) {
-                    return dev.name.clone();
-                }
-            }
+        let guid = guid_for(&crate::platform::windows::adapter_guids(), friendly);
+        if let Some(name) = match_npcap_device(friendly, guid.as_deref(), None, &devices) {
+            return Ok(name);
         }
 
-        // Fallback: return original and let pcap produce its own error.
-        friendly.to_string()
+        // No PowerShell, or the GUID matched no Npcap device: try the address
+        // ipconfig reports for this adapter.
+        let ipv4 = crate::platform::collect_interface_info()
+            .ok()
+            .and_then(|info| {
+                info.into_iter()
+                    .find(|i| i.name.eq_ignore_ascii_case(friendly))
+                    .and_then(|i| i.ipv4)
+            });
+        match_npcap_device(friendly, None, ipv4.as_deref(), &devices).ok_or_else(|| {
+            format!(
+                "No Npcap adapter matches '{friendly}' ({} listed) — is Npcap bound to it?",
+                devices.len()
+            )
+        })
     }
 }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -6,6 +6,9 @@ pub mod macos;
 /// from `main` before anything touches libpcap.
 #[cfg(target_os = "windows")]
 pub mod npcap;
+/// Friendly-name -> Npcap device matching. Platform-neutral so the matching
+/// is tested everywhere; only the Windows lookups that feed it are gated.
+pub mod npcap_device;
 #[cfg(target_os = "macos")]
 pub mod pktap;
 /// Kernel-derived process identity — every platform, including the fallback
@@ -76,7 +79,10 @@ pub fn default_route_interface() -> Option<String> {
     #[cfg(target_os = "macos")]
     return macos::default_route_interface();
 
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(target_os = "windows")]
+    return windows::default_route_interface();
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     None
 }
 

--- a/src/platform/npcap_device.rs
+++ b/src/platform/npcap_device.rs
@@ -1,0 +1,266 @@
+//! Mapping a Windows adapter's friendly name to the Npcap device that captures
+//! it. Platform-neutral so the matching is unit-tested on every host; only the
+//! lookups feeding it (`platform::windows`) are Windows-only.
+//!
+//! Npcap names devices `\Device\NPF_{GUID}`, and the description it attaches
+//! is the driver's — "Hyper-V Virtual Ethernet Adapter", "Intel(R) Ethernet
+//! Connection I219-LM", or just "Microsoft" for a Wi-Fi card — never the
+//! friendly name ipconfig shows ("Ethernet", "vEthernet (WSL)"). The old
+//! resolver matched the friendly name as a *substring of the description*, so
+//! "Ethernet" landed on whichever Hyper-V virtual adapter Npcap listed first,
+//! and "vEthernet (WSL)" matched nothing and was handed to Npcap verbatim,
+//! which fails with "The system cannot find the file specified" (issue #51).
+//!
+//! The GUID is the adapter's identity, so that is matched first. The IPv4
+//! address is the fallback for a host where PowerShell is unavailable, and an
+//! exact description match the last resort. There is no substring matching.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+/// What the matcher needs from a `pcap::Device`, without depending on pcap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PcapDevice {
+    pub name: String,
+    pub desc: Option<String>,
+    pub addrs: Vec<IpAddr>,
+}
+
+/// Pick the Npcap device for `friendly`, given what is known about it.
+///
+/// `guid` is the adapter's interface GUID with or without braces; `ipv4` its
+/// address as ipconfig prints it. Both are optional because each comes from a
+/// separate lookup that can fail independently.
+pub fn match_npcap_device(
+    friendly: &str,
+    guid: Option<&str>,
+    ipv4: Option<&str>,
+    devices: &[PcapDevice],
+) -> Option<String> {
+    // Already a device path: `\Device\NPF_{...}` or `\\.\...`.
+    if friendly.starts_with("\\Device\\") || friendly.starts_with("\\\\") {
+        return Some(friendly.to_string());
+    }
+
+    if let Some(guid) = guid {
+        let want = format!("npf_{{{}}}", normalise_guid(guid));
+        if let Some(dev) = devices
+            .iter()
+            .find(|d| d.name.to_ascii_lowercase().ends_with(&want))
+        {
+            return Some(dev.name.clone());
+        }
+    }
+
+    if let Some(addr) = ipv4.and_then(|s| s.trim().parse::<IpAddr>().ok()) {
+        // Require a unique owner: two adapters can share an address
+        // transiently (APIPA, a bridge and its member), and guessing between
+        // them is the bug this replaces.
+        let mut owners = devices.iter().filter(|d| d.addrs.contains(&addr));
+        if let (Some(dev), None) = (owners.next(), owners.next()) {
+            return Some(dev.name.clone());
+        }
+    }
+
+    devices
+        .iter()
+        .find(|d| {
+            d.desc
+                .as_deref()
+                .is_some_and(|desc| desc.eq_ignore_ascii_case(friendly))
+        })
+        .map(|d| d.name.clone())
+}
+
+fn normalise_guid(guid: &str) -> String {
+    guid.trim()
+        .trim_start_matches('{')
+        .trim_end_matches('}')
+        .to_ascii_lowercase()
+}
+
+/// Parse `Get-NetAdapter | Select-Object Name,InterfaceGuid | ConvertTo-Json`
+/// into friendly name -> GUID. PowerShell emits a bare object for one adapter
+/// and an array for several.
+pub fn parse_adapter_guids(json: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return map;
+    };
+    let items = match value {
+        serde_json::Value::Array(items) => items,
+        obj @ serde_json::Value::Object(_) => vec![obj],
+        _ => return map,
+    };
+    for item in items {
+        let (Some(name), Some(guid)) = (item["Name"].as_str(), item["InterfaceGuid"].as_str())
+        else {
+            continue;
+        };
+        if !name.is_empty() && !guid.is_empty() {
+            map.insert(name.to_string(), normalise_guid(guid));
+        }
+    }
+    map
+}
+
+/// Case-insensitive lookup: ipconfig and Get-NetAdapter agree on the name,
+/// but not always on its case.
+pub fn guid_for(guids: &HashMap<String, String>, friendly: &str) -> Option<String> {
+    guids.get(friendly).cloned().or_else(|| {
+        guids
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(friendly))
+            .map(|(_, v)| v.clone())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dev(name: &str, desc: &str, addrs: &[&str]) -> PcapDevice {
+        PcapDevice {
+            name: name.into(),
+            desc: Some(desc.into()),
+            addrs: addrs.iter().map(|a| a.parse().unwrap()).collect(),
+        }
+    }
+
+    // The reporter's machine, as Npcap lists it: two Hyper-V virtual
+    // adapters, then the physical NIC. Descriptions carry no friendly name.
+    fn hyperv_host() -> Vec<PcapDevice> {
+        vec![
+            dev(
+                "\\Device\\NPF_{AAAA1111-0000-0000-0000-000000000001}",
+                "Hyper-V Virtual Ethernet Adapter",
+                &["172.29.16.1"],
+            ),
+            dev(
+                "\\Device\\NPF_{AAAA1111-0000-0000-0000-000000000002}",
+                "Hyper-V Virtual Ethernet Adapter #2",
+                &["172.17.0.1"],
+            ),
+            dev(
+                "\\Device\\NPF_{BBBB2222-0000-0000-0000-000000000003}",
+                "Intel(R) Ethernet Connection (17) I219-LM",
+                &["192.168.1.50"],
+            ),
+        ]
+    }
+
+    #[test]
+    fn guid_picks_the_physical_nic_not_the_first_ethernet_description() {
+        let got = match_npcap_device(
+            "Ethernet",
+            Some("{BBBB2222-0000-0000-0000-000000000003}"),
+            None,
+            &hyperv_host(),
+        );
+        assert_eq!(
+            got.as_deref(),
+            Some("\\Device\\NPF_{BBBB2222-0000-0000-0000-000000000003}")
+        );
+    }
+
+    #[test]
+    fn guid_match_is_case_insensitive_and_brace_tolerant() {
+        let got = match_npcap_device(
+            "vEthernet (WSL)",
+            Some("aaaa1111-0000-0000-0000-000000000001"),
+            None,
+            &hyperv_host(),
+        );
+        assert_eq!(
+            got.as_deref(),
+            Some("\\Device\\NPF_{AAAA1111-0000-0000-0000-000000000001}")
+        );
+    }
+
+    #[test]
+    fn vethernet_resolves_by_address_without_powershell() {
+        let got = match_npcap_device("vEthernet (WSL)", None, Some("172.29.16.1"), &hyperv_host());
+        assert_eq!(
+            got.as_deref(),
+            Some("\\Device\\NPF_{AAAA1111-0000-0000-0000-000000000001}")
+        );
+    }
+
+    #[test]
+    fn shared_address_is_not_guessed() {
+        let mut devs = hyperv_host();
+        devs[1].addrs = vec!["192.168.1.50".parse().unwrap()];
+        assert_eq!(
+            match_npcap_device("Ethernet", None, Some("192.168.1.50"), &devs),
+            None
+        );
+    }
+
+    #[test]
+    fn no_substring_match_on_description() {
+        // This is the #51 failure: "Ethernet" is inside every description here.
+        assert_eq!(
+            match_npcap_device("Ethernet", None, None, &hyperv_host()),
+            None
+        );
+    }
+
+    #[test]
+    fn exact_description_is_the_last_resort() {
+        let got = match_npcap_device(
+            "hyper-v virtual ethernet adapter #2",
+            None,
+            None,
+            &hyperv_host(),
+        );
+        assert_eq!(
+            got.as_deref(),
+            Some("\\Device\\NPF_{AAAA1111-0000-0000-0000-000000000002}")
+        );
+    }
+
+    #[test]
+    fn device_paths_pass_through() {
+        let path = "\\Device\\NPF_{CCCC3333-0000-0000-0000-000000000009}";
+        assert_eq!(
+            match_npcap_device(path, None, None, &[]).as_deref(),
+            Some(path)
+        );
+        assert_eq!(
+            match_npcap_device("\\\\.\\pipe\\x", None, None, &[]).as_deref(),
+            Some("\\\\.\\pipe\\x")
+        );
+    }
+
+    #[test]
+    fn parses_get_netadapter_array_and_single_object() {
+        let many = r#"[{"Name":"Ethernet","InterfaceGuid":"{BBBB2222-0000-0000-0000-000000000003}"},
+                       {"Name":"vEthernet (WSL)","InterfaceGuid":"{AAAA1111-0000-0000-0000-000000000001}"},
+                       {"Name":"","InterfaceGuid":"{DEAD}"}]"#;
+        let map = parse_adapter_guids(many);
+        assert_eq!(map.len(), 2);
+        assert_eq!(
+            map["vEthernet (WSL)"],
+            "aaaa1111-0000-0000-0000-000000000001"
+        );
+
+        let one = r#"{"Name":"Wi-Fi","InterfaceGuid":"{1234ABCD-0000-0000-0000-000000000000}"}"#;
+        let map = parse_adapter_guids(one);
+        assert_eq!(map["Wi-Fi"], "1234abcd-0000-0000-0000-000000000000");
+
+        assert!(parse_adapter_guids("not json").is_empty());
+        assert!(parse_adapter_guids("42").is_empty());
+    }
+
+    #[test]
+    fn guid_lookup_ignores_case() {
+        let map = parse_adapter_guids(
+            r#"{"Name":"Wi-Fi","InterfaceGuid":"{1234ABCD-0000-0000-0000-000000000000}"}"#,
+        );
+        assert_eq!(
+            guid_for(&map, "wi-fi").as_deref(),
+            Some("1234abcd-0000-0000-0000-000000000000")
+        );
+        assert_eq!(guid_for(&map, "Ethernet"), None);
+    }
+}

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -269,3 +269,43 @@ fn collect_mtu_map() -> HashMap<String, u32> {
 
     map
 }
+
+/// Friendly adapter name -> interface GUID, from `Get-NetAdapter`. The GUID is
+/// what Npcap puts in its device name, so this is the one reliable bridge from
+/// the names ipconfig shows to the device pcap opens (issue #51). Empty when
+/// PowerShell is unavailable; the caller falls back to matching by address.
+pub fn adapter_guids() -> HashMap<String, String> {
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            "Get-NetAdapter -IncludeHidden | Select-Object Name,InterfaceGuid | ConvertTo-Json -Compress",
+        ])
+        .output();
+    match output {
+        Ok(out) if out.status.success() => {
+            super::npcap_device::parse_adapter_guids(&String::from_utf8_lossy(&out.stdout))
+        }
+        _ => HashMap::new(),
+    }
+}
+
+/// Friendly name of the adapter carrying the lowest-metric IPv4 default
+/// route. `InterfaceAlias` is the same name ipconfig and Get-NetAdapter use.
+pub fn default_route_interface() -> Option<String> {
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            "(Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0' -ErrorAction SilentlyContinue \
+             | Sort-Object { $_.RouteMetric + $_.InterfaceMetric } \
+             | Select-Object -First 1).InterfaceAlias",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let alias = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!alias.is_empty()).then_some(alias)
+}


### PR DESCRIPTION
Fixes #51.

## What was wrong

The Windows resolver mapped the friendly interface name ipconfig shows ("Ethernet", "vEthernet (WSL)") to Npcap's `\Device\NPF_{GUID}` by matching it as a **substring of the device description**. That description is the driver's name ("Hyper-V Virtual Ethernet Adapter", "Intel(R) Ethernet Connection I219-LM", or just "Microsoft" for Wi-Fi), never the adapter's friendly name. So:

- **"Ethernet" showed only mDNS.** The substring "ethernet" matched the first Hyper-V virtual adapter Npcap listed, which only sees the WSL switch.
- **"vEthernet (WSL)" failed with "file not found".** Nothing contained that string, so the friendly name went to Npcap verbatim and the open failed with Windows error 2.

Not Hyper-V specific. Any host with two adapters whose descriptions contain "Ethernet", or any Wi-Fi adapter, hits the same thing, with or without admin.

## What changed

- `src/platform/npcap_device.rs` (new): platform-neutral matcher. Interface GUID first, then the unique owner of the adapter's IPv4 address, then an exact description match. No substring matching. Nine tests, including the reporter's adapter layout.
- `src/platform/windows.rs`: `adapter_guids` via `Get-NetAdapter`, and `default_route_interface` via `Get-NetRoute`, so the route-based default pick from #43 applies on Windows too.
- `src/collectors/packets/mod.rs`: the resolver returns a result, runs on the capture thread rather than the key handler, and reports "No Npcap adapter matches 'X'" instead of the raw open error.
- Version bumped to 0.30.4, tagged `v0.30.4` on this branch.

## Verification

- 958 tests pass; fmt and clippy clean.
- No Windows toolchain on the dev box. The Windows-only code was type-checked by un-gating it in a scratch copy; every API it uses is portable. The PowerShell calls have not run on a real Windows machine yet.

## Merge note

`v0.30.4` points at this branch's release commit. Merge with a merge commit or rebase, not squash, so the tag stays in `main`'s history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmCSxQT3Rz3QZvrr8PkzHB
